### PR TITLE
ActiveRemote::Base#save produces false negative on additional calls

### DIFF
--- a/lib/active_remote/persistence.rb
+++ b/lib/active_remote/persistence.rb
@@ -8,7 +8,16 @@ module ActiveRemote
         include ActiveRemote::Persistence::InstanceMethods
         include ActiveRemote::RPC
 
+        # Allow users to create callbacks around a `save` call.
+        #
         define_model_callbacks :save
+
+        # Before a save occurs, ensure that we
+        # clear out the errors list.
+        #
+        set_callback :save, :before do |remote|
+          remote.errors.clear
+        end
       end
     end
 

--- a/spec/lib/active_remote/persistence_spec.rb
+++ b/spec/lib/active_remote/persistence_spec.rb
@@ -181,18 +181,26 @@ describe ActiveRemote::Persistence do
     end
 
     context "when the record is saved" do
-      before { subject.errors.clear }
-
       it "returns true" do
+        subject.should_receive(:has_errors?) { false }
         subject.save.should be_true
       end
     end
 
     context "when the record is not saved" do
+      it "returns false" do
+        subject.should_receive(:has_errors?) { true }
+        subject.save.should be_false
+      end
+    end
+
+    context "when the record has errors before the save" do
       before { subject.errors[:base] << "Boom!" }
 
-      it "returns false" do
-        subject.save.should be_false
+      it "clears the errors before the save" do
+        subject.errors.should_not be_empty
+        subject.save.should be_true
+        subject.errors.should be_empty
       end
     end
   end


### PR DESCRIPTION
When creating or updating a record with ActiveRemote you can get a false negative with the save command.

``` ruby
user  = User.new
user.save # => false
user.errors # => [ "Need an email" ]

user.email = "foo@bar.com"
user.save # => false
user.errors # => [ "Need an email" ]
```

The contrived example above shows a workflow for producing the issue:
1. Use `.new` to instantiate an unsaved object.
2. Save the object with `#save` producing an error from the service.
3. The errors list is populated with information about the failure.
4. Correct the error by applying the correct attributes.
5. Save the object again. `#save` returns false because the errors list from the previous issue was not cleared on the save.

I'll submit a pull request for it sometime in the next few days, but just wanted to document to make sure I remember what happened.
