### PR TITLE
Fix paging

### DIFF
--- a/lib/active_remote/serializers/protobuf.rb
+++ b/lib/active_remote/serializers/protobuf.rb
@@ -37,7 +37,7 @@ module ActiveRemote
         #
         def build_message(message_class, attributes)
           attributes.inject(message_class.new) do |message, (key, value)|
-            if field = message.get_field_by_name(key)
+            if field = message.get_field_by_name(key) || message.get_ext_field_by_name(key)
 
               # Override the value based on the field type where issues
               # exist in the protobuf gem.


### PR DESCRIPTION
ActiveRemote failed to send paging options to the server when the proto
definition put the options field in an extension.
