### PR TITLE
Use an instance variable to track new records

### DIFF
--- a/active_remote.gemspec
+++ b/active_remote.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   ##
   # Development Dependencies
   #
+  s.add_development_dependency "better_receive"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rspec-pride"

--- a/lib/active_remote/base.rb
+++ b/lib/active_remote/base.rb
@@ -38,6 +38,7 @@ module ActiveRemote
 
     def initialize(*)
       @attributes ||= {}
+      @new_record = true
 
       skip_dirty_tracking do
         run_callbacks :initialize do

--- a/lib/active_remote/persistence.rb
+++ b/lib/active_remote/persistence.rb
@@ -119,11 +119,25 @@ module ActiveRemote
         return respond_to?(:errors) && errors.present?
       end
 
+      # Instantiate a record with the given remote attributes. Generally used
+      # when retrieving records that already exist, so @new_record is set to false.
+      #
+      def instantiate(record)
+        skip_dirty_tracking do
+          assign_attributes(record)
+        end
+
+        run_callbacks :initialize
+
+        @new_record = false
+        self
+      end
+
       # Returns true if the remote record hasn't been saved yet; otherwise,
       # returns false.
       #
       def new_record?
-        return self[:guid].nil?
+        @new_record
       end
 
       # Returns true if the remote record has been saved; otherwise, returns false.
@@ -207,6 +221,7 @@ module ActiveRemote
           assign_attributes(last_response.to_hash)
           add_errors_from_response
 
+          @new_record = has_errors?
           success?
         end
       end

--- a/lib/active_remote/serialization.rb
+++ b/lib/active_remote/serialization.rb
@@ -31,9 +31,10 @@ module ActiveRemote
     def serialize_records
       return nil unless last_response.respond_to?(:records)
 
-      last_response.records.map do |record|
-        remote = self.class.new(record.to_hash)
-        remote
+      last_response.records.map do |remote_record|
+        record = self.class.allocate
+        record.instantiate(remote_record.to_hash)
+        record
       end
     end
   end

--- a/spec/lib/active_remote/persistence_spec.rb
+++ b/spec/lib/active_remote/persistence_spec.rb
@@ -146,7 +146,7 @@ describe ActiveRemote::Persistence do
 
   describe "#new_record?" do
     context "when the record is persisted" do
-      subject { Tag.new(:guid => 'foo') }
+      subject { Tag.allocate.instantiate(:guid => 'foo') }
 
       its(:new_record?) { should be_false }
     end
@@ -159,13 +159,13 @@ describe ActiveRemote::Persistence do
   end
 
   describe "#persisted?" do
-    context "when the record has a guid" do
-      subject { Tag.new(:guid => 'foo') }
+    context "when the record is persisted" do
+      subject { Tag.allocate.instantiate(:guid => 'foo') }
 
       its(:persisted?) { should be_true }
     end
 
-    context "when the record does not have a guid" do
+    context "when the record is not persisted" do
       subject { Tag.new }
 
       its(:persisted?) { should be_false }
@@ -194,7 +194,7 @@ describe ActiveRemote::Persistence do
     context "when the record is not new" do
       let(:attributes) { { 'guid' => 'foo' } }
 
-      subject { Tag.new(attributes) }
+      subject { Tag.allocate.instantiate(attributes) }
 
       it "updates the record" do
         subject.should_receive(:execute).with(:update, attributes)
@@ -204,14 +204,14 @@ describe ActiveRemote::Persistence do
 
     context "when the record is saved" do
       it "returns true" do
-        subject.should_receive(:has_errors?) { false }
+        subject.better_stub(:has_errors?) { false }
         subject.save.should be_true
       end
     end
 
     context "when the record is not saved" do
       it "returns false" do
-        subject.should_receive(:has_errors?) { true }
+        subject.better_stub(:has_errors?) { true }
         subject.save.should be_false
       end
     end
@@ -267,7 +267,7 @@ describe ActiveRemote::Persistence do
     after { Tag.any_instance.unstub(:execute) }
 
     it "runs update callbacks" do
-      tag = Tag.new({:guid => "123"})
+      tag = Tag.allocate.instantiate({:guid => "123"})
       tag.should_receive(:after_update_callback)
       tag.update_attributes({})
     end


### PR DESCRIPTION
The previous approach of tracking new records based on the presence of a GUID was flawed (i.e. does not work with records that do not have GUIDs or when a GUID is set on a non-persisted record).

Instead, take the Rails approach of using an instance variable to track if a record is new, adding a new method (:instantiate) to initialize records that are already known to be persisted.

// @abrandoned 
