### PR TITLE
add class level instantiate method to mirror the

### DIFF
--- a/lib/active_remote/persistence.rb
+++ b/lib/active_remote/persistence.rb
@@ -51,6 +51,16 @@ module ActiveRemote
         remote
       end
 
+      # Instantiate a record with the given remote attributes. Generally used
+      # when retrieving records that already exist, so @new_record is set to false.
+      #
+      def instantiate(attributes, options = {})
+        new_object = self.new.instantiate(attributes)
+        new_object.readonly! if options[:readonly]
+
+        new_object
+      end
+
       # Mark the class as readonly. Overrides instance-level readonly, making
       # any instance of this class readonly.
       def readonly!
@@ -144,6 +154,12 @@ module ActiveRemote
       #
       def persisted?
         return ! new_record?
+      end
+
+      # Sets the instance to be a readonly object
+      #
+      def readonly!
+        @readonly = true
       end
 
       # Returns true if the remote class or remote record is readonly; otherwise, returns false.

--- a/spec/lib/active_remote/persistence_spec.rb
+++ b/spec/lib/active_remote/persistence_spec.rb
@@ -130,6 +130,15 @@ describe ActiveRemote::Persistence do
     end
   end
 
+  describe "#readonly?" do
+    context "when the record is created through instantiate with options[:readonly]" do
+      subject { Tag.instantiate({:guid => 'foo'}, :readonly => true) }
+
+      its(:new_record?) { should be_false }
+      its(:readonly?) { should be_true }
+    end
+  end
+
   describe "#has_errors?" do
     context "when errors are not present" do
       before { subject.errors.clear }
@@ -145,6 +154,12 @@ describe ActiveRemote::Persistence do
   end
 
   describe "#new_record?" do
+    context "when the record is created through instantiate" do
+      subject { Tag.instantiate(:guid => 'foo') }
+
+      its(:new_record?) { should be_false }
+    end
+
     context "when the record is persisted" do
       subject { Tag.allocate.instantiate(:guid => 'foo') }
 


### PR DESCRIPTION
ActiveRecord interface for instantiating a record that
is not new

Also added an instance level readonly! and options hash to the
class level instantiate so it can be marked as readonly on instantiation

allows single method instantiation of a remote model and instance level readonly-ness

@liveh2o 
