### PR TITLE
Re-introduce the protobuf serializer

### DIFF
--- a/lib/active_remote/rpc.rb
+++ b/lib/active_remote/rpc.rb
@@ -1,6 +1,12 @@
+require 'active_remote/serializers/protobuf'
+
 module ActiveRemote
   module RPC
     extend ActiveSupport::Concern
+
+    included do
+      include Serializers::Protobuf
+    end
 
     module ClassMethods
 
@@ -17,7 +23,9 @@ module ActiveRemote
       def request(rpc_method, request_args)
         return request_args unless request_args.is_a?(Hash)
 
-        request_type(rpc_method).new(request_args)
+        message_class = request_type(rpc_method)
+        fields = fields_from_attributes(message_class, request_args)
+        message_class.new(fields)
       end
 
       # Return the class applicable to the request for the given rpc method.

--- a/lib/active_remote/serializers/protobuf.rb
+++ b/lib/active_remote/serializers/protobuf.rb
@@ -1,0 +1,103 @@
+module ActiveRemote
+  module Serializers
+    module Protobuf
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        def fields_from_attributes(message_class, attributes)
+          Fields.from_attributes(message_class, attributes)
+        end
+      end
+
+      def fields_from_attributes(message_class, attributes)
+        Fields.from_attributes(message_class, attributes)
+      end
+
+      class Fields
+        attr_reader :attributes, :message_class
+
+        ##
+        # Constructor!
+        #
+        def initialize(message_class, attributes = {})
+          @attributes = attributes
+          @message_class = message_class
+        end
+
+        ##
+        # Class methods
+        #
+        def self.from_attributes(message_class, attributes)
+          fields = self.new(message_class, attributes)
+          fields.from_attributes
+        end
+
+        ##
+        # Instance methods
+        #
+        def from_attributes
+          attributes.inject({}) do |hash, (key, value)|
+            field = message_class.get_field(key, true) # Check extension fields, too
+            value = Field.from_attribute(field, value) if field
+
+            hash[key] = value
+            hash
+          end
+        end
+      end
+
+      class Field
+        attr_reader :field, :value
+
+        ##
+        # Constructor!
+        #
+        def initialize(field, value)
+          @field = field
+          @value = value
+        end
+
+        ##
+        # Class methods
+        #
+        def self.from_attribute(field, value)
+          field = self.new(field, value)
+          field.from_attribute
+        end
+
+        ##
+        # Instance methods
+        #
+        def from_attribute
+          case
+          when field.repeated_message? then
+            repeated_message_value
+          when field.message? then
+            message_value
+          when field.repeated? then
+            repeated_value
+          else
+            value
+          end
+        end
+
+      private
+
+        def message_value(attributes = nil)
+          attributes ||= value
+          attributes.is_a?(Hash) ? Fields.from_attributes(field.type_class, attributes) : attributes
+        end
+
+        def repeated_message_value
+          repeated_value.map do |attributes|
+            message_value(attributes)
+          end
+        end
+
+        def repeated_value
+          value.is_a?(Array) ? value : [ value ]
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/active_remote/serializers/protobuf_spec.rb
+++ b/spec/lib/active_remote/serializers/protobuf_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe ActiveRemote::Serializers::Protobuf::Fields do
+  describe ".from_attributes" do
+    let(:ready_value) { { :records => [ { :name => 'Cool Post', :errors => [ { :message => 'Boom!' } ] } ] } }
+    let(:value) { { :records => { :name => 'Cool Post', :errors => { :message => 'Boom!' } } } }
+
+    it "gets protobuf-ready fields from attributes" do
+      described_class.from_attributes(Generic::Remote::Posts, value).should eq ready_value
+    end
+  end
+end
+
+describe ActiveRemote::Serializers::Protobuf::Field do
+  describe ".from_attribute" do
+    context "when field is a repeated message" do
+      let(:field) { Generic::Remote::Posts.get_field(:records) }
+
+      context "and the value is not an array" do
+        let(:ready_value) { [ { :name => 'Cool Post', :errors => [ { :message => 'Boom!' } ] } ] }
+        let(:value) { { :name => 'Cool Post', :errors => { :message => 'Boom!' } } }
+
+        it "gets protobuf-ready fields from the value" do
+          described_class.from_attribute(field, value).should eq ready_value
+        end
+      end
+    end
+
+    context "when field is a message" do
+      let(:field) { Generic::Remote::Post.get_field(:category) }
+
+      context "and value is a hash" do
+        let(:ready_value) { { :name => 'Film', :errors => [ { :message => 'Boom!' } ] } }
+        let(:value) { { :name => 'Film', :errors => { :message => 'Boom!' } } }
+
+        it "gets protobuf-ready fields from the value" do
+          described_class.from_attribute(field, value).should eq ready_value
+        end
+      end
+    end
+
+    context "when field is repeated" do
+      let(:field) { Generic::Remote::PostRequest.get_field(:name) }
+
+      context "and the value is not an array" do
+        let(:ready_value) { [ 'Cool Post' ] }
+        let(:value) { 'Cool Post' }
+
+        it "gets protobuf-ready fields from the value" do
+          described_class.from_attribute(field, value).should eq ready_value
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The serializer was removed under the assumption that it was largely handling coercion, which was unnecessary because Protobuf handled that already. This turned out to only be partially true. It was also ensuring that repeated values were wrapped in an array.

Re-introduce the Protobuf serializer, but this time simply handle wrapping any repeated fields in arrays (if they aren't already).

// @localshred @abrandoned 
