### PR TITLE
Reintroduce typecasting to the Protobuf serializer

### DIFF
--- a/spec/lib/active_remote/serializers/protobuf_spec.rb
+++ b/spec/lib/active_remote/serializers/protobuf_spec.rb
@@ -51,5 +51,38 @@ describe ActiveRemote::Serializers::Protobuf::Field do
         end
       end
     end
+
+    # TODO: Find a better way to write this. It works for now, but it's not
+    # very clear and is hard to track down since failures don't include a
+    # description.
+    #
+    # TODO: Consider adding specific specs for typecasting dates to integers
+    # or strings since that's what prompted the re-introduction of the
+    # typecasting.
+    #
+    context "when typecasting fields" do
+      let(:string_value) { double(:string, :to_s => '') }
+
+      def typecasts(field, conversion)
+        field = Serializer.get_field(field, true)
+        described_class.from_attribute(field, conversion.first[0]).should eq conversion.first[1]
+      end
+
+      it { typecasts(:bool_field, '0' => false) }
+      it { typecasts(:bytes_field, string_value => '') }
+      it { typecasts(:double_field, 0 => 0.0) }
+      it { typecasts(:fixed32_field, '0' => 0) }
+      it { typecasts(:fixed64_field, '0' => 0) }
+      it { typecasts(:float_field, 0 => 0.0) }
+      it { typecasts(:int32_field, '0' => 0) }
+      it { typecasts(:int64_field, '0' => 0) }
+      it { typecasts(:sfixed32_field, '0' => 0) }
+      it { typecasts(:sfixed64_field, '0' => 0) }
+      it { typecasts(:sint32_field, '0' => 0) }
+      it { typecasts(:sint64_field, '0' => 0) }
+      it { typecasts(:string_field, string_value => '') }
+      it { typecasts(:uint32_field, '0' => 0) }
+      it { typecasts(:uint64_field, '0' => 0) }
+    end
   end
 end

--- a/spec/support/protobuf.rb
+++ b/spec/support/protobuf.rb
@@ -1,4 +1,5 @@
 require 'support/protobuf/author.pb'
 require 'support/protobuf/category.pb'
 require 'support/protobuf/post.pb'
+require 'support/protobuf/serializer.pb'
 require 'support/protobuf/tag.pb'


### PR DESCRIPTION
The Protobuf serializer used to handle coercing values to Protobuf field types. It was (incorrectly) removed, which broke things that relied on passing values directly to non-persistance methods (i.e. creating requests with values other than the internal attributes) or values directly from web requests (i.e. the Rails params hash).

Reintroduce typecasting using the Active Attr typecasters. Add specs to ensure things work as expected. Fixes #18.

// @abrandoned @localshred 
