### PR TITLE
account for having empty records in the parse_response

### DIFF
--- a/lib/active_remote/bulk.rb
+++ b/lib/active_remote/bulk.rb
@@ -107,7 +107,7 @@ module ActiveRemote
           records.collect!(&:to_hash)
         end
 
-        return records.first if records.first.has_key?(:records)
+        return records.first if records.first && records.first.has_key?(:records)
 
         # If we made it this far, build a bulk-formatted hash.
         return { :records => records }

--- a/spec/lib/active_remote/bulk_spec.rb
+++ b/spec/lib/active_remote/bulk_spec.rb
@@ -42,12 +42,17 @@ describe ActiveRemote::Bulk do
 
   describe ".parse_records" do
     let(:records) { [ Hash.new ] }
+    let(:empty_records) { [] }
     let(:attribute_record) {
       record = double(Hash)
       record.stub(:attributes) { {} }
       record
     }
-    let(:records) { [ Hash.new ] }
+
+    it "returns an empty array when given empty records" do
+      parsed_records = { :records => [] }
+      Tag.parse_records(empty_records).should eq(parsed_records)
+    end
 
     it "preps records to be built into a bulk request" do
       parsed_records = { :records => records }


### PR DESCRIPTION
in the bulk helpers; currently the response being empty
causes the call to fail because it is trying to introspect
on a record that is not present

@liveh2o @hqmq
