### PR TITLE
Make protobuf adapter threadsafe

### DIFF
--- a/lib/active_remote/rpc_adapters/protobuf_adapter.rb
+++ b/lib/active_remote/rpc_adapters/protobuf_adapter.rb
@@ -5,7 +5,7 @@ module ActiveRemote
     class ProtobufAdapter
       include Serializers::Protobuf
 
-      attr_reader :last_request, :last_response, :service_class
+      attr_reader :service_class
 
       ##
       # Constructor!
@@ -17,9 +17,10 @@ module ActiveRemote
       # Invoke an RPC call to the service for the given rpc method.
       #
       def execute(rpc_method, request_args)
-        @last_request = request(rpc_method, request_args)
+        last_request = request(rpc_method, request_args)
+        last_response = nil
 
-        service_class.client.__send__(rpc_method, @last_request) do |c|
+        service_class.client.__send__(rpc_method, last_request) do |c|
           # In the event of service failure, raise the error.
           c.on_failure do |error|
             raise ActiveRemoteError, error.message
@@ -27,11 +28,11 @@ module ActiveRemote
 
           # In the event of service success, assign the response.
           c.on_success do |response|
-            @last_response = response
+            last_response = response
           end
         end
 
-        @last_response
+        last_response
       end
 
       private


### PR DESCRIPTION
Since there is only a single instance of the rpc adater at the class
level that all service calls use, when working in a multithreaded
environment, we end up in a case where multiple threads are sharing the
same instance of the rpc adater class and therefore sharing the same
instance variables.

The problem causes undetermined results from service calls.  By removing
the instance variables and using local variables, it is safe to use the
same instance of the rpc adater from multiple threads.

An alternative solution would be to use a new instance of the rpc adater
for each service call, if you want to keep the instance varaibles.
