### PR TITLE
Add support for validations

### DIFF
--- a/active_remote.gemspec
+++ b/active_remote.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rspec-pride"
-  s.add_development_dependency "pry-nav"
+  s.add_development_dependency "pry"
   s.add_development_dependency "protobuf-rspec", ">= 1.0"
   s.add_development_dependency "simplecov"
 end

--- a/lib/active_remote/base.rb
+++ b/lib/active_remote/base.rb
@@ -15,6 +15,7 @@ require 'active_remote/rpc'
 require 'active_remote/scope_keys'
 require 'active_remote/search'
 require 'active_remote/serialization'
+require 'active_remote/validations'
 
 module ActiveRemote
   class Base
@@ -38,6 +39,10 @@ module ActiveRemote
     # Overrides some methods, providing support for dirty tracking,
     # so it needs to be included last.
     include Dirty
+
+    # Overrides persistence methods, so it must included after
+    include Validations
+    include ActiveModel::Validations::Callbacks
 
     attr_reader :last_request, :last_response
 

--- a/lib/active_remote/errors.rb
+++ b/lib/active_remote/errors.rb
@@ -9,6 +9,17 @@ module ActiveRemote
   class ReadOnlyRemoteRecord < ActiveRemoteError
   end
 
+  # Raised by ActiveRemote::Validations when save is called on an invalid record.
+  class RemoteRecordInvalid < ActiveRemoteError
+    attr_reader :record
+
+    def initialize(record)
+      @record = record
+      errors = @record.errors.full_messages.join(', ')
+      super(errors)
+    end
+  end
+
   # Raised by ActiveRemove::Base.find when remote record is not found when
   # searching with the given arguments.
   class RemoteRecordNotFound < ActiveRemoteError

--- a/lib/active_remote/persistence.rb
+++ b/lib/active_remote/persistence.rb
@@ -176,9 +176,9 @@ module ActiveRemote
     #
     # Also runs any before/after save callbacks that are defined.
     #
-    def save
+    def save(*args)
       run_callbacks :save do
-        create_or_update
+        create_or_update(*args)
       end
     end
 
@@ -192,8 +192,8 @@ module ActiveRemote
     #
     # Also runs any before/after save callbacks that are defined.
     #
-    def save!
-      save || raise(RemoteRecordNotSaved)
+    def save!(*args)
+      save(*args) || raise(RemoteRecordNotSaved)
     end
 
     # Returns true if the record doesn't have errors; otherwise, returns false.
@@ -245,9 +245,9 @@ module ActiveRemote
     # are created, existing records are updated. If the record is marked as
     # readonly, an ActiveRemote::ReadOnlyRemoteRecord is raised.
     #
-    def create_or_update
+    def create_or_update(*args)
       raise ReadOnlyRemoteRecord if readonly?
-      new_record? ? create : update
+      new_record? ? create : update(*args)
     end
 
     # Handles updating a remote object and serializing it's attributes and

--- a/lib/active_remote/validations.rb
+++ b/lib/active_remote/validations.rb
@@ -1,0 +1,64 @@
+module ActiveRemote
+  module Validations
+    extend ActiveSupport::Concern
+
+    # Attempts to save the record like Persistence, but will run
+    # validations and return false if the record is invalid
+    #
+    # Validations can be skipped by passing :validate => false
+    #
+    # example Save a record
+    #   post.save
+    #
+    # example Save a record, skip validations
+    #  post.save(:validate => false)
+    #
+    def save(options = {})
+      perform_validations(options) ? super : false
+    end
+
+    # Attempts to save the record like Persistence, but will raise
+    # ActiveRemote::RemoteRecordInvalid if the record is not valid
+    #
+    # Validations can be skipped by passing :validate => false
+    #
+    # example Save a record, raise and error if invalid
+    #   post.save!
+    #
+    # example Save a record, skip validations
+    #  post.save!(:validate => false)
+    #
+    def save!(options = {})
+      perform_validations(options) ? super : raise_validation_error
+    end
+
+    # Runs all the validations within the specified context. Returns true if
+    # no errors are found, false otherwise.
+    #
+    # Aliased as validate.
+    #
+    # example Is the record valid?
+    #   post.valid?
+    #
+    # example Is the record valid for creation?
+    #   post.valid?(:create)
+    #
+    def valid?(context = nil)
+      context ||= (new_record? ? :create : :update)
+      output = super(context)
+      errors.empty? && output
+    end
+
+    alias_method :validate, :valid?
+
+  protected
+
+    def raise_validation_error
+      fail(::ActiveRemote::RemoteRecordInvalid.new(self))
+    end
+
+    def perform_validations(options = {})
+      options[:validate] == false || valid?(options[:context])
+    end
+  end
+end

--- a/spec/lib/active_remote/dirty_spec.rb
+++ b/spec/lib/active_remote/dirty_spec.rb
@@ -88,7 +88,7 @@ describe ActiveRemote::Dirty do
 
     it "clears previous changes" do
       new_record = post.instantiate(record.to_hash)
-      new_record.previous_changes.should be_nil
+      new_record.previous_changes.should eq({})
     end
 
     it "clears changes" do

--- a/spec/lib/active_remote/validations_spec.rb
+++ b/spec/lib/active_remote/validations_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe ActiveRemote::Validations do
+  let(:invalid_record) { ::Post.new }
+  let(:valid_record) { ::Post.new(:name => 'test') }
+
+  before { valid_record.stub(:create_or_update).and_return(true) }
+  before { invalid_record.stub(:create_or_update).and_return(true) }
+
+  describe 'save' do
+    context 'valid record' do
+      it 'returns true' do
+        result = valid_record.save
+        result.should be true
+      end
+    end
+
+    context 'invalid record' do
+      it 'returns false' do
+        result = invalid_record.save
+        result.should be false
+      end
+    end
+  end
+
+  describe 'save!' do
+    context 'valid record' do
+      it 'returns true' do
+        result = valid_record.save!
+        result.should be true
+      end
+    end
+
+    context 'invalid record' do
+      it 'raises invalid record error' do
+        expect { invalid_record.save! }.to raise_error(ActiveRemote::RemoteRecordInvalid)
+      end
+    end
+  end
+
+  describe 'valid?' do
+    context 'valid record' do
+      it 'returns true' do
+        result = valid_record.valid?
+        result.should be true
+      end
+    end
+
+    context 'invalid record' do
+      it 'returns false' do
+        result = invalid_record.valid?
+        result.should be false
+      end
+    end
+  end
+end

--- a/spec/support/models/post.rb
+++ b/spec/support/models/post.rb
@@ -16,4 +16,6 @@ class Post < ::ActiveRemote::Base
   belongs_to :coauthor, :class_name => '::Author'
   belongs_to :bestseller, :class_name => '::Author', :foreign_key => :bestseller_guid
   belongs_to :user, :class_name => '::Author', :scope => :user_guid
+
+  validates :name, :presence => true
 end


### PR DESCRIPTION
This wires up ActiveModel::Validations to run when calling `save` and `save!`, in the same way that [active record does it](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/validations.rb).

This also includes ActiveModel::Validations::Callbacks which will add `before_validation`, `after_validation`, etc.