### PR TITLE
Fix failing spec.

### DIFF
--- a/spec/lib/active_remote/persistence_spec.rb
+++ b/spec/lib/active_remote/persistence_spec.rb
@@ -199,6 +199,7 @@ describe ActiveRemote::Persistence do
 
   describe "#save" do
     it "runs save callbacks" do
+      allow(subject).to receive(:run_callbacks).with(:validation).and_return(true)
       expect(subject).to receive(:run_callbacks).with(:save)
       subject.save
     end


### PR DESCRIPTION
This assertation to the run_callbacks method was picking up the
validation callback, and also returning nil which cancelled the callback
chain.