### PR TITLE
Add update_attribute method

### DIFF
--- a/lib/active_remote/persistence.rb
+++ b/lib/active_remote/persistence.rb
@@ -202,6 +202,22 @@ module ActiveRemote
       return ! has_errors?
     end
 
+    # Updates a single attribute and saves the record.
+    # This is especially useful for boolean flags on existing records. Also note that
+    #
+    # * Validation is skipped.
+    # * Callbacks are invoked.
+    # * Updates all the attributes that are dirty in this object.
+    #
+    # This method raises an ActiveRemote::ReadOnlyRemoteRecord  if the
+    # attribute is marked as readonly.
+    def update_attribute(name, value)
+      raise ReadOnlyRemoteRecord if readonly?
+      name = name.to_s
+      send("#{name}=", value)
+      save(:validate => false)
+    end
+
     # Updates the attributes of the remote record from the passed-in hash and
     # saves the remote record. If the object is invalid, it will have error
     # messages and false will be returned.

--- a/spec/lib/active_remote/persistence_spec.rb
+++ b/spec/lib/active_remote/persistence_spec.rb
@@ -283,6 +283,36 @@ describe ActiveRemote::Persistence do
     end
   end
 
+  describe "#update_attribute" do
+    let(:tag) { Tag.allocate.instantiate({:guid => "123"}) }
+
+    before { allow(Tag.rpc).to receive(:execute).and_return(HashWithIndifferentAccess.new) }
+    after { allow(Tag.rpc).to receive(:execute).and_call_original }
+
+    it "runs update callbacks" do
+      expect(tag).to receive(:after_update_callback)
+      tag.update_attribute(:name, "foo")
+    end
+
+    it "updates a remote record" do
+      expect(Tag.rpc).to receive(:execute).with(:update, tag.scope_key_hash)
+      tag.update_attribute(:name, "foo")
+    end
+
+    before { allow(subject).to receive(:save) }
+    after { allow(subject).to receive(:save).and_call_original }
+
+    it "assigns new attributes" do
+      expect(subject).to receive(:name=).with("foo")
+      subject.update_attribute(:name, "foo")
+    end
+
+    it "saves the record" do
+      expect(subject).to receive(:save)
+      subject.update_attribute(:name, "foo")
+    end
+  end
+
   describe "#update_attributes" do
     let(:attributes) { HashWithIndifferentAccess.new(:name => 'bar') }
     let(:tag) { Tag.allocate.instantiate({:guid => "123"}) }


### PR DESCRIPTION
This adds the `update_attribute` method, to increase compatibility with the ActiveRecord interface.

http://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-update_attribute