### PR TITLE
Fix broken update functionality

### DIFF
--- a/lib/active_remote/dirty.rb
+++ b/lib/active_remote/dirty.rb
@@ -84,7 +84,7 @@ module ActiveRemote
 
     # Override #update to only send changed attributes.
     #
-    def update(*)
+    def remote_update(*)
       super(changed)
     end
   end

--- a/spec/lib/active_remote/persistence_spec.rb
+++ b/spec/lib/active_remote/persistence_spec.rb
@@ -295,7 +295,7 @@ describe ActiveRemote::Persistence do
     end
 
     it "updates a remote record" do
-      expect(Tag.rpc).to receive(:execute).with(:update, tag.scope_key_hash)
+      expect(Tag.rpc).to receive(:execute).with(:update, {"name" => "foo", "guid" => "123"})
       tag.update_attribute(:name, "foo")
     end
 


### PR DESCRIPTION
The update method in the persistence module was renamed, and this
methods also needs to be renamed to overwrite the correct method.