### PR TITLE
Skip mass-assignment protection when instantiating

### DIFF
--- a/lib/active_remote/persistence.rb
+++ b/lib/active_remote/persistence.rb
@@ -129,7 +129,7 @@ module ActiveRemote
     #
     def instantiate(record)
       skip_dirty_tracking do
-        assign_attributes(record)
+        assign_attributes(record, :without_protection => true)
       end
 
       # TODO: figure out how to safely run after_find/search callbacks here


### PR DESCRIPTION
When calling `instantiate`, we see a signficant speed improvement by skipping mass-assignment protection. Since this method is intended for use with searching for remote records, skipping that protection should be fine.

// @brianstien @abrandoned 