### PR TITLE
Fix attribute defaults from active_attr

### DIFF
--- a/lib/active_remote/attribute_defaults.rb
+++ b/lib/active_remote/attribute_defaults.rb
@@ -1,0 +1,100 @@
+require "active_support/concern"
+require "active_support/core_ext/object/duplicable"
+
+module ActiveRemote
+  # AttributeDefaults allows defaults to be declared for your attributes
+  #
+  # Defaults are declared by passing the :default option to the attribute
+  # class method. If you need the default to be dynamic, pass a lambda, Proc,
+  # or any object that responds to #call as the value to the :default option
+  # and the result will calculated on initialization. These dynamic defaults
+  # can depend on the values of other attributes when those attributes are
+  # assigned using MassAssignment or BlockInitialization.
+  #
+  # @example Usage
+  #   class Person
+  #     include ActiveRemote::AttributeDefaults
+  #
+  #     attribute :first_name, :default => "John"
+  #     attribute :last_name, :default => "Doe"
+  #   end
+  #
+  #   person = Person.new
+  #   person.first_name #=> "John"
+  #   person.last_name #=> "Doe"
+  #
+  # @example Dynamic Default
+  #   class Event
+  #     include ActiveAttr::MassAssignment
+  #     include ActiveRemote::AttributeDefaults
+  #
+  #     attribute :start_date
+  #     attribute :end_date, :default => lambda { start_date }
+  #   end
+  #
+  #   event = Event.new(:start_date => Date.parse("2012-01-01"))
+  #   event.end_date.to_s #=> "2012-01-01"
+  #
+  module AttributeDefaults
+    extend ActiveSupport::Concern
+
+    # Applies the attribute defaults
+    #
+    # Applies all the default values to any attributes not yet set, avoiding
+    # any attribute setter logic, such as dirty tracking.
+    #
+    # @example Usage
+    #   class Person
+    #     include ActiveRemote::AttributeDefaults
+    #
+    #     attribute :first_name, :default => "John"
+    #   end
+    #
+    #   person = Person.new
+    #   person.first_name #=> "John"
+    #
+    def apply_defaults(defaults=attribute_defaults)
+      @attributes ||= {}
+      defaults.each do |name, value|
+        # instance variable is used here to avoid any dirty tracking in attribute setter methods
+        @attributes[name] = value if @attributes[name].nil?
+      end
+    end
+
+    # Calculates the attribute defaults from the attribute definitions
+    #
+    # @example Usage
+    #   class Person
+    #     include ActiveAttr::AttributeDefaults
+    #
+    #     attribute :first_name, :default => "John"
+    #   end
+    #
+    #   Person.new.attribute_defaults #=> {"first_name"=>"John"}
+    #
+    def attribute_defaults
+      attributes_map { |name| _attribute_default name }
+    end
+
+    # Applies attribute default values
+    #
+    def initialize(*)
+      super
+      apply_defaults
+    end
+
+    private
+
+    # Calculates an attribute default
+    #
+    def _attribute_default(attribute_name)
+      default = self.class.attributes[attribute_name][:default]
+
+      case
+      when default.respond_to?(:call) then instance_exec(&default)
+      when default.duplicable? then default.dup
+      else default
+      end
+    end
+  end
+end

--- a/lib/active_remote/base.rb
+++ b/lib/active_remote/base.rb
@@ -2,6 +2,7 @@ require 'active_model/callbacks'
 require 'active_attr/model'
 
 require 'active_remote/association'
+require 'active_remote/attribute_defaults'
 require 'active_remote/attributes'
 require 'active_remote/bulk'
 require 'active_remote/config'
@@ -23,7 +24,9 @@ module ActiveRemote
     extend ActiveModel::Callbacks
 
     include ActiveAttr::BasicModel
+    include ActiveAttr::Attributes
     include ActiveAttr::BlockInitialization
+    include ActiveAttr::ChainableInitialization
     include ActiveAttr::Logger
     include ActiveAttr::MassAssignment
     include ActiveAttr::AttributeDefaults
@@ -31,6 +34,7 @@ module ActiveRemote
     include ActiveAttr::Serialization
 
     include Association
+    include AttributeDefaults
     include Attributes
     include Bulk
     include DSL

--- a/spec/lib/active_remote/attribute_defaults_spec.rb
+++ b/spec/lib/active_remote/attribute_defaults_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+describe "attribute defailts" do
+  let(:test_class) { ::DefaultAuthor }
+
+  describe "string" do
+    it "defaults to a string" do
+      record = test_class.new
+      expect(record.name).to eq("John Doe")
+    end
+  end
+
+  describe "lambda" do
+    it "calls the lambda" do
+      record = test_class.new
+      expect(record.guid).to eq(100)
+    end
+  end
+
+  describe "array" do
+    it "defaults to an array" do
+      record = test_class.new
+      expect(record.books).to eq([])
+    end
+  end
+end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -1,5 +1,6 @@
 require 'support/models/message_with_options'
 require 'support/models/author'
+require 'support/models/default_author'
 require 'support/models/category'
 require 'support/models/post'
 require 'support/models/tag'

--- a/spec/support/models/default_author.rb
+++ b/spec/support/models/default_author.rb
@@ -1,0 +1,12 @@
+require 'support/protobuf/author.pb'
+
+##
+# Define a generic class that inherits from active remote base
+#
+class DefaultAuthor < ::ActiveRemote::Base
+  service_class ::Generic::Remote::AuthorService
+
+  attribute :guid, :default => lambda { 100 }
+  attribute :name, :default => "John Doe"
+  attribute :books, :default => []
+end


### PR DESCRIPTION
Attribute defaults were broken by the change to attribute initialization
and typecasting.

This pulls over the active_attr attribute defaults, and fixes them to
work with the way active_remote is doing attribute initialization and
typecasting.

We could probably monkeypatch this in but I thought this approach
was cleaner.  Let me know what you think.