### PR TITLE
pass errors through on bulk rpc calls

### DIFF
--- a/lib/active_remote/serialization.rb
+++ b/lib/active_remote/serialization.rb
@@ -18,7 +18,11 @@ module ActiveRemote
       #   Tag.serialize_records(records) # => [ Tag#{:name => 'foo'} ]
       #
       def serialize_records(records)
-        records.map { |record| instantiate(record.to_hash) }
+        records.map do |record|
+          model = instantiate(record.to_hash)
+          model.add_errors(record.errors) if record.respond_to?(:errors)
+          model
+        end
       end
     end
 

--- a/spec/lib/active_remote/bulk_spec.rb
+++ b/spec/lib/active_remote/bulk_spec.rb
@@ -51,6 +51,18 @@ describe ActiveRemote::Bulk do
         Tag.__send__(bulk_method, tags)
       end
     end
+
+    context "response with errors" do
+      let(:record_with_errors) { double(:record, :errors => [double(:error, :messages => ["whine"], :field => "wat")], :to_hash => {}) }
+      let(:response) { double(:response, :records => [record_with_errors]) }
+      let(:tag) { Generic::Remote::Tag.new }
+      let(:tags) { Generic::Remote::Tags.new(:records => [ tag ]) }
+
+      it "sets the errors on the inflated ActiveRemote objects" do
+        records = Tag.__send__(bulk_method, tags)
+        expect(records.first.errors["wat"]).to eq(["whine"])
+      end
+    end
   end
 
   describe ".create_all" do


### PR DESCRIPTION
I ran into a case recently where I was calling `MyModel.create_all(...)` and then checking the results for `errors.present?`, but I never got errors back.

This PR adds the step of adding the remote errors whenever we are serializing remote data into `ActiveRemote` objects. This will also allow error messages to come through in `search` endpoints as well.

/cc @liveh2o @abrandoned @newellista