### PR TITLE
Adds setters for has_one and belongs_to

### DIFF
--- a/lib/active_remote/association.rb
+++ b/lib/active_remote/association.rb
@@ -42,6 +42,7 @@ module ActiveRemote
 
           search_hash.values.any?(&:nil?) ? nil : klass.search(search_hash).first
         end
+        create_setter_method(belongs_to_klass, options)
       end
 
       # Create a `has_many` association for a given remote resource.
@@ -121,6 +122,7 @@ module ActiveRemote
 
           search_hash.values.any?(&:nil?) ? nil : klass.search(search_hash).first
         end
+        create_setter_method(has_one_klass, options)
       end
 
       # when requiring an attribute on your search, we verify the attribute
@@ -132,11 +134,22 @@ module ActiveRemote
 
     private
 
+      def create_setter_method(associated_klass, options={})
+        writer_method = "#{associated_klass}=".to_sym
+        define_method(writer_method) do |new_value|
+          klass_name = options.fetch(:class_name){ associated_klass }
+          klass = klass_name.to_s.classify.constantize
+
+          instance_variable_set(:"@#{new_value.class.name.demodulize.underscore}", new_value)
+          new_value
+        end
+      end
+
       def perform_association(associated_klass, options={})
         define_method(associated_klass) do
           klass_name = options.fetch(:class_name){ associated_klass }
           klass = klass_name.to_s.classify.constantize
-
+          
           self.class.validate_scoped_attributes(klass, self.class, options) if options.has_key?(:scope)
 
           value = instance_variable_get(:"@#{associated_klass}")

--- a/lib/active_remote/association.rb
+++ b/lib/active_remote/association.rb
@@ -42,7 +42,6 @@ module ActiveRemote
 
           search_hash.values.any?(&:nil?) ? nil : klass.search(search_hash).first
         end
-        create_setter_method(belongs_to_klass, options)
       end
 
       # Create a `has_many` association for a given remote resource.
@@ -122,7 +121,6 @@ module ActiveRemote
 
           search_hash.values.any?(&:nil?) ? nil : klass.search(search_hash).first
         end
-        create_setter_method(has_one_klass, options)
       end
 
       # when requiring an attribute on your search, we verify the attribute
@@ -149,7 +147,7 @@ module ActiveRemote
         define_method(associated_klass) do
           klass_name = options.fetch(:class_name){ associated_klass }
           klass = klass_name.to_s.classify.constantize
-          
+
           self.class.validate_scoped_attributes(klass, self.class, options) if options.has_key?(:scope)
 
           value = instance_variable_get(:"@#{associated_klass}")
@@ -161,6 +159,8 @@ module ActiveRemote
 
           return value
         end
+
+        create_setter_method(associated_klass, options)
       end
     end
   end

--- a/spec/lib/active_remote/association_spec.rb
+++ b/spec/lib/active_remote/association_spec.rb
@@ -12,6 +12,7 @@ describe ActiveRemote::Association do
       subject { Post.new(:author_guid => author_guid, :user_guid => user_guid) }
 
       it { is_expected.to respond_to(:author) }
+      it { is_expected.to respond_to(:author=) }
 
       it "searches the associated model for a single record" do
         expect(Author).to receive(:search).with(:guid => subject.author_guid).and_return(records)
@@ -62,7 +63,6 @@ describe ActiveRemote::Association do
           end
         end
       end
-
     end
 
     context "specific association with class name" do
@@ -74,6 +74,10 @@ describe ActiveRemote::Association do
       it "searches the associated model for a single record" do
         expect(Author).to receive(:search).with(:guid => subject.author_guid).and_return(records)
         expect(subject.coauthor).to eq record
+      end
+
+      it "should create a setter method" do
+        expect(subject).to respond_to(:coauthor=)
       end
     end
 
@@ -181,6 +185,7 @@ describe ActiveRemote::Association do
     subject { Category.new(category_attributes) }
 
     it { is_expected.to respond_to(:author) }
+    it { is_expected.to respond_to(:author=) }
 
     it "searches the associated model for all associated records" do
       expect(Author).to receive(:search).with(:category_guid => subject.guid).and_return(records)
@@ -213,6 +218,10 @@ describe ActiveRemote::Association do
       it "searches the associated model for a single record" do
         expect(Author).to receive(:search).with(:category_guid => subject.guid).and_return(records)
         expect(subject.senior_author).to eq record
+      end
+
+      it "should create a setter method" do
+        expect(subject).to respond_to(:senior_author=)
       end
     end
 


### PR DESCRIPTION
We weren't defining setters during these associations before. Next steps will add a setter for has_many. I feel like that's a little different because it deals with a number of records rather than just one, so there needs to be some check that the current method does not do.

Part of #45.

@mmmries @localshred @liveh2o