### PR TITLE
Add query methods from active_attr

### DIFF
--- a/lib/active_remote/base.rb
+++ b/lib/active_remote/base.rb
@@ -11,6 +11,7 @@ require 'active_remote/dsl'
 require 'active_remote/integration'
 require 'active_remote/persistence'
 require 'active_remote/primary_key'
+require 'active_remote/query_attributes'
 require 'active_remote/rpc'
 require 'active_remote/scope_keys'
 require 'active_remote/search'
@@ -34,6 +35,7 @@ module ActiveRemote
     include ::ActiveRemote::Integration
     include ::ActiveRemote::Persistence
     include ::ActiveRemote::PrimaryKey
+    include ::ActiveRemote::QueryAttributes
     include ::ActiveRemote::RPC
     include ::ActiveRemote::ScopeKeys
     include ::ActiveRemote::Search

--- a/lib/active_remote/query_attributes.rb
+++ b/lib/active_remote/query_attributes.rb
@@ -1,0 +1,45 @@
+require "active_support/concern"
+require "active_support/core_ext/object/blank"
+
+module ActiveRemote
+  # QueryAttributes provides instance methods for querying attributes.
+  #
+  # @example Usage
+  #   class Person < ::ActiveRemote::Base
+  #     attribute :name
+  #   end
+  #
+  #   person = Person.new
+  #   person.name? #=> false
+  #   person.name = "Chris Griego"
+  #   person.name? #=> true
+  #
+  module QueryAttributes
+    extend ::ActiveSupport::Concern
+
+    included do
+      attribute_method_suffix "?"
+    end
+
+    # Test the presence of an attribute
+    #
+    # See {Typecasting::BooleanTypecaster.call} for more details.
+    #
+    # @example Query an attribute
+    #   person.query_attribute(:name)
+    #
+    def query_attribute(name)
+      if respond_to?("#{name}?")
+        send("#{name}?")
+      else
+        raise ::ActiveRemote::UnknownAttributeError, "unknown attribute: #{name}"
+      end
+    end
+
+  private
+
+    def attribute?(name)
+      ::ActiveRemote::Typecasting::BooleanTypecaster.call(read_attribute(name))
+    end
+  end
+end

--- a/spec/lib/active_remote/query_attribute_spec.rb
+++ b/spec/lib/active_remote/query_attribute_spec.rb
@@ -1,0 +1,171 @@
+require "spec_helper"
+
+describe ::ActiveRemote::QueryAttributes do
+  subject { ::Author.new }
+
+  describe "#query_attribute" do
+    it "raises when getting an undefined attribute" do
+      expect { subject.query_attribute(:foobar) }.to raise_error(::ActiveRemote::UnknownAttributeError)
+    end
+
+    it "is false when the attribute is false" do
+      subject.name = false
+      expect(subject.name?).to eq false
+    end
+
+    it "is true when the attribute is true" do
+      subject.name = true
+      expect(subject.name?).to eq true
+    end
+
+    it "is false when the attribute is nil" do
+      subject.name = nil
+      expect(subject.name?).to eq false
+    end
+
+    it "is true when the attribute is an Object" do
+      subject.name = Object.new
+      expect(subject.name?).to eq true
+    end
+
+    it "is false when the attribute is an empty string" do
+      subject.name = ""
+      expect(subject.name?).to eq false
+    end
+
+    it "is true when the attribute is a non-empty string" do
+      subject.name = "Chris"
+      expect(subject.name?).to eq true
+    end
+
+    it "is false when the attribute is 0" do
+      subject.name = 0
+      expect(subject.name?).to eq false
+    end
+
+    it "is true when the attribute is 1" do
+      subject.name = 1
+      expect(subject.name?).to eq true
+    end
+
+    it "is false when the attribute is 0.0" do
+      subject.name = 0.0
+      expect(subject.name?).to eq false
+    end
+
+    it "is true when the attribute is 0.1" do
+      subject.name = 0.1
+      expect(subject.name?).to eq true
+    end
+
+    it "is false when the attribute is a zero BigDecimal" do
+      subject.name = BigDecimal.new("0.0")
+      expect(subject.name?).to eq false
+    end
+
+    it "is true when the attribute is a non-zero BigDecimal" do
+      subject.name = BigDecimal.new("0.1")
+      expect(subject.name?).to eq true
+    end
+
+    it "is true when the attribute is -1" do
+      subject.name = -1
+      expect(subject.name?).to eq true
+    end
+
+    it "is false when the attribute is -0.0" do
+      subject.name = -0.0
+      expect(subject.name?).to eq false
+    end
+
+    it "is true when the attribute is -0.1" do
+      subject.name = -0.1
+      expect(subject.name?).to eq true
+    end
+
+    it "is false when the attribute is a negative zero BigDecimal" do
+      subject.name = BigDecimal.new("-0.0")
+      expect(subject.name?).to eq false
+    end
+
+    it "is true when the attribute is a negative BigDecimal" do
+      subject.name = BigDecimal.new("-0.1")
+      expect(subject.name?).to eq true
+    end
+
+    it "is false when the attribute is '0'" do
+      subject.name = "0"
+      expect(subject.name?).to eq false
+    end
+
+    it "is true when the attribute is '1'" do
+      subject.name = "1"
+      expect(subject.name?).to eq true
+    end
+
+    it "is false when the attribute is '0.0'" do
+      subject.name = "0.0"
+      expect(subject.name?).to eq false
+    end
+
+    it "is true when the attribute is '0.1'" do
+      subject.name = "0.1"
+      expect(subject.name?).to eq true
+    end
+
+    it "is true when the attribute is '-1'" do
+      subject.name = "-1"
+      expect(subject.name?).to eq true
+    end
+
+    it "is false when the attribute is '-0.0'" do
+      subject.name = "-0.0"
+      expect(subject.name?).to eq false
+    end
+
+    it "is true when the attribute is '-0.1'" do
+      subject.name = "-0.1"
+      expect(subject.name?).to eq true
+    end
+
+    it "is true when the attribute is 'true'" do
+      subject.name = "true"
+      expect(subject.name?).to eq true
+    end
+
+    it "is false when the attribute is 'false'" do
+      subject.name = "false"
+      expect(subject.name?).to eq false
+    end
+
+    it "is true when the attribute is 't'" do
+      subject.name = "t"
+      expect(subject.name?).to eq true
+    end
+
+    it "is false when the attribute is 'f'" do
+      subject.name = "f"
+      expect(subject.name?).to eq false
+    end
+
+    it "is true when the attribute is 'T'" do
+      subject.name = "T"
+      expect(subject.name?).to eq true
+    end
+
+    it "is false when the attribute is 'F'" do
+      subject.name = "F"
+      expect(subject.name?).to eq false
+    end
+
+    it "is true when the attribute is 'TRUE'" do
+      subject.name = "TRUE"
+      expect(subject.name?).to eq true
+    end
+
+    it "is false when the attribute is 'FALSE" do
+      subject.name = "FALSE"
+      expect(subject.name?).to eq false
+    end
+  end
+end


### PR DESCRIPTION
In the process of active_attr removal I mistakenly removed the query attributes.  This brings them back.