### PR TITLE
Init from rpc

### DIFF
--- a/lib/active_remote/attribute_definition.rb
+++ b/lib/active_remote/attribute_definition.rb
@@ -56,6 +56,12 @@ module ActiveRemote
       raise TypeError, "can't convert #{name.class} into Symbol" unless name.respond_to? :to_sym
       @name = name.to_sym
       @options = options
+
+      if @options[:type]
+        typecaster = ::ActiveRemote::Typecasting::TYPECASTER_MAP[@options[:type]]
+        fail ::ActiveRemote::UnknownType unless typecaster
+        @options[:typecaster] = typecaster
+      end
     end
 
     # Returns the code that would generate the attribute definition

--- a/lib/active_remote/base.rb
+++ b/lib/active_remote/base.rb
@@ -69,6 +69,17 @@ module ActiveRemote
       end
     end
 
+    # Initialize an object with the attributes hash directly
+    # When used with allocate, bypasses initialize
+    def init_with(attributes)
+      @attributes = attributes
+      @new_record = false
+
+      run_callbacks :initialize
+
+      self
+    end
+
     def freeze
       @attributes.freeze; self
     end

--- a/lib/active_remote/persistence.rb
+++ b/lib/active_remote/persistence.rb
@@ -49,8 +49,9 @@ module ActiveRemote
       # Instantiate a record with the given remote attributes. Generally used
       # when retrieving records that already exist, so @new_record is set to false.
       #
-      def instantiate(attributes, options = {})
-        new_object = self.new.instantiate(attributes)
+      def instantiate(new_attributes, options = {})
+        attributes = self.build_from_rpc(new_attributes)
+        new_object = self.allocate.init_with(attributes)
         new_object.readonly! if options[:readonly]
 
         new_object

--- a/lib/active_remote/persistence.rb
+++ b/lib/active_remote/persistence.rb
@@ -128,24 +128,9 @@ module ActiveRemote
     # Instantiate a record with the given remote attributes. Generally used
     # when retrieving records that already exist, so @new_record is set to false.
     #
-    def instantiate(record)
-      @attributes ||= begin
-        attribute_names = self.class.attribute_names
-        Hash[attribute_names.map { |key| [key, nil] }]
-      end
-
-      skip_dirty_tracking do
-        assign_attributes(record)
-      end
-
-      # TODO: figure out how to safely run after_find/search callbacks here
-      # currently, several functions use this code path, so an alternate path
-      # may need to be added
-
-      run_callbacks :initialize
-
-      @new_record = false
-      self
+    def instantiate(new_attributes)
+      new_attributes = self.class.build_from_rpc(new_attributes)
+      init_with(new_attributes)
     end
 
     # Returns true if the remote record hasn't been saved yet; otherwise,

--- a/lib/active_remote/rpc.rb
+++ b/lib/active_remote/rpc.rb
@@ -10,6 +10,22 @@ module ActiveRemote
     end
 
     module ClassMethods
+      # Builds an attribute hash that be assigned directly
+      # to an object from an rpc response
+      def build_from_rpc(new_attributes)
+        new_attributes = new_attributes.stringify_keys
+        constructed_attributes = {}
+        attributes.each do |name, definition|
+          if new_attributes[name].nil?
+            constructed_attributes[name] = nil
+          elsif definition[:typecaster]
+            constructed_attributes[name] = definition[:typecaster].call(new_attributes[name])
+          else
+            constructed_attributes[name] = new_attributes[name]
+          end
+        end
+        constructed_attributes
+      end
 
       # Execute an RPC call to the remote service and return the raw response.
       #

--- a/lib/active_remote/typecasting.rb
+++ b/lib/active_remote/typecasting.rb
@@ -30,21 +30,10 @@ module ActiveRemote
     def attribute=(name, value)
       return super if value.nil?
 
-      typecaster = _attribute_typecaster(name)
+      typecaster = self.class.attributes[name][:typecaster]
       return super unless typecaster
 
       super(name, typecaster.call(value))
-    end
-
-    def _attribute_typecaster(attribute_name)
-      self.class.attributes[attribute_name][:typecaster] || _typecaster_for(attribute_name)
-    end
-
-    def _typecaster_for(attribute_name)
-      type = self.class.attributes[attribute_name][:type]
-      return nil unless type
-
-      TYPECASTER_MAP[type]
     end
 
     module ClassMethods

--- a/spec/lib/active_remote/rpc_spec.rb
+++ b/spec/lib/active_remote/rpc_spec.rb
@@ -3,6 +3,34 @@ require 'spec_helper'
 describe ::ActiveRemote::RPC do
   subject { ::Tag.new }
 
+  describe ".build_from_rpc" do
+    let(:new_attributes) { { :name => "test" } }
+
+    context "missing attributes from rpc" do
+      it "initializes to nil" do
+        expect(::Tag.build_from_rpc(new_attributes)).to include("guid" => nil)
+      end
+    end
+
+    context "extra attributes from rpc" do
+      let(:new_attributes) { { :foobar => "test" } }
+
+      it "ignores unknown attributes" do
+        expect(::Tag.build_from_rpc(new_attributes)).to_not include("foobar" => "test")
+      end
+    end
+
+    context "typecasted attributes" do
+      let(:new_attributes) { { :birthday => "2017-01-01" } }
+
+      it "calls the typecasters" do
+        expect(
+          ::TypecastedAuthor.build_from_rpc(new_attributes)
+        ).to include("birthday" => "2017-01-01".to_datetime)
+      end
+    end
+  end
+
   describe ".remote_call" do
     let(:args) { double(:args) }
     let(:response) { double(:response) }


### PR DESCRIPTION
This improves the performance of the handoff from rpc response to creating a new object.  There are some significant time savings by bypassing all of the setters.

This will set the attributes hash directly when we get a response from rpc, bypassing the setters but still doing type casting.