### PR TITLE
Add granular protobuf errors for ActiveRemote

### DIFF
--- a/lib/active_remote/errors.rb
+++ b/lib/active_remote/errors.rb
@@ -23,7 +23,7 @@ module ActiveRemote
     end
   end
 
-  # Raised by ActiveRemove::Base.find when remote record is not found when
+  # Raised by ActiveRemote::Base.find when remote record is not found when
   # searching with the given arguments.
   class RemoteRecordNotFound < ActiveRemoteError
     attr_accessor :remote_record_class
@@ -46,5 +46,36 @@ module ActiveRemote
   end
 
   class UnknownAttributeError < ActiveRemoteError
+  end
+
+  # Errors from Protobuf
+  class BadRequestDataError < ActiveRemoteError
+  end
+
+  class BadRequestProtoError < ActiveRemoteError
+  end
+
+  class ServiceNotFoundError < ActiveRemoteError
+  end
+
+  class MethodNotFoundError < ActiveRemoteError
+  end
+
+  class RpcError < ActiveRemoteError
+  end
+
+  class RpcFailedError < ActiveRemoteError
+  end
+
+  class InvalidRequestProtoError < ActiveRemoteError
+  end
+
+  class BadResponseProtoError < ActiveRemoteError
+  end
+
+  class UnknownHostError < ActiveRemoteError
+  end
+
+  class IOError < ActiveRemoteError
   end
 end

--- a/lib/active_remote/rpc_adapters/protobuf_adapter.rb
+++ b/lib/active_remote/rpc_adapters/protobuf_adapter.rb
@@ -22,7 +22,8 @@ module ActiveRemote
         service_class.client.__send__(rpc_method, @last_request) do |c|
           # In the event of service failure, raise the error.
           c.on_failure do |error|
-            raise ActiveRemoteError, error.message
+            protobuf_error = protobuf_error_class(error)
+            raise protobuf_error, error.message
           end
 
           # In the event of service success, assign the response.
@@ -35,6 +36,33 @@ module ActiveRemote
       end
 
       private
+
+      def protobuf_error_class(error)
+        case error.error_type
+        when ::Protobuf::Socketrpc::ErrorReason::BAD_REQUEST_DATA
+          ::ActiveRemote::BadRequestDataError
+        when ::Protobuf::Socketrpc::ErrorReason::BAD_REQUEST_PROTO
+          ::ActiveRemote::BadRequestProtoError
+        when ::Protobuf::Socketrpc::ErrorReason::SERVICE_NOT_FOUND
+          ::ActiveRemote::ServiceNotFoundError
+        when ::Protobuf::Socketrpc::ErrorReason::METHOD_NOT_FOUND
+          ::ActiveRemote::MethodNotFound
+        when ::Protobuf::Socketrpc::ErrorReason::RPC_ERROR
+          ::ActiveRemote::RpcError
+        when ::Protobuf::Socketrpc::ErrorReason::RPC_FAILED_ERROR
+          ::ActiveRemote::RpcFailedError
+        when ::Protobuf::Socketrpc::ErrorReason::INVALID_REQUEST_PROTO
+          ::ActiveRemote::InvalidRequestProtoError
+        when ::Protobuf::Socketrpc::ErrorReason::BAD_RESPONSE_PROTO
+          ::ActiveRemote::BadResponseProtoError
+        when ::Protobuf::Socketrpc::ErrorReason::UNKNOWN_HOST
+          ::ActiveRemote::UnknownHostError
+        when ::Protobuf::Socketrpc::ErrorReason::IO_ERROR
+          ::ActiveRemote::IOError
+        else
+          ActiveRemoteError
+        end
+      end
 
       # Return a protobuf request object for the given rpc request.
       #

--- a/lib/active_remote/rpc_adapters/protobuf_adapter.rb
+++ b/lib/active_remote/rpc_adapters/protobuf_adapter.rb
@@ -46,7 +46,7 @@ module ActiveRemote
         when ::Protobuf::Socketrpc::ErrorReason::SERVICE_NOT_FOUND
           ::ActiveRemote::ServiceNotFoundError
         when ::Protobuf::Socketrpc::ErrorReason::METHOD_NOT_FOUND
-          ::ActiveRemote::MethodNotFound
+          ::ActiveRemote::MethodNotFoundError
         when ::Protobuf::Socketrpc::ErrorReason::RPC_ERROR
           ::ActiveRemote::RpcError
         when ::Protobuf::Socketrpc::ErrorReason::RPC_FAILED_ERROR


### PR DESCRIPTION
From https://github.com/liveh2o/active_remote/issues/39

Example set of errors https://github.com/ruby-protobuf/protobuf/blob/master/lib/protobuf/rpc/error/client_error.rb

This will make it so we bubble up the type of error given from Protobuf

@liveh2o @abrandoned @mmmries 