### PR TITLE
Allow primary_key to be set on create

### DIFF
--- a/lib/active_remote/persistence.rb
+++ b/lib/active_remote/persistence.rb
@@ -238,7 +238,6 @@ module ActiveRemote
       run_callbacks :create do
         # Use the getter here so we get the type casting.
         new_attributes = attributes
-        new_attributes.delete(primary_key.to_s)
 
         response = rpc.execute(:create, new_attributes)
 

--- a/spec/lib/active_remote/persistence_spec.rb
+++ b/spec/lib/active_remote/persistence_spec.rb
@@ -208,7 +208,7 @@ describe ::ActiveRemote::Persistence do
       subject { Tag.new }
 
       it "creates the record" do
-        expected_attributes = subject.attributes.reject { |key, value| key == "guid" }
+        expected_attributes = subject.attributes
         expect(rpc).to receive(:execute).with(:create, expected_attributes)
         subject.save
       end


### PR DESCRIPTION
ActiveRecord allows the primary key to be set on create. This makes
ActiveRemote#create behave the same way by allowing the primary_key
attribute to be sent in a create operation.

@liveh2o 