### PR TITLE
Handle invalid DateTime attributes gracefully

### DIFF
--- a/lib/active_remote/typecasting/date_time_typecaster.rb
+++ b/lib/active_remote/typecasting/date_time_typecaster.rb
@@ -3,6 +3,7 @@ module ActiveRemote
     class DateTimeTypecaster
       def self.call(value)
         value.to_datetime if value.respond_to?(:to_datetime)
+      rescue NoMethodError, ArgumentError
       end
     end
   end

--- a/spec/lib/active_remote/typecasting_spec.rb
+++ b/spec/lib/active_remote/typecasting_spec.rb
@@ -14,6 +14,13 @@ describe ::ActiveRemote::Typecasting do
       record = test_class.new(:birthday => "2016-01-01")
       expect(record.birthday).to eq(DateTime.parse("2016-01-01"))
     end
+
+    context "invalid date" do
+      it "sets attribute to nil" do
+        record = test_class.new(:birthday => "23451234")
+        expect(record.birthday).to be_nil
+      end
+    end
   end
 
   describe "float" do


### PR DESCRIPTION
The Date typecaster will gracefully handle invalid dates, but DateTime
does not. This changes the behavior of DateTime types to match the
behavior of Date types.