### PR TITLE
Reset fields on create or update

### DIFF
--- a/lib/active_remote/attribute_assignment.rb
+++ b/lib/active_remote/attribute_assignment.rb
@@ -36,6 +36,10 @@ module ActiveRemote
       _assign_attributes(sanitize_for_mass_assignment(attributes))
     end
 
+    def reset_attributes
+      @attributes = self.class.send(:default_attributes_hash).dup
+    end
+
     private
 
     def _assign_attributes(attributes)

--- a/lib/active_remote/base.rb
+++ b/lib/active_remote/base.rb
@@ -53,7 +53,7 @@ module ActiveRemote
     define_model_callbacks :initialize, :only => :after
 
     def initialize(attributes = {})
-      @attributes = self.class.send(:default_attributes_hash).dup
+      reset_attributes
 
       assign_attributes(attributes) if attributes
 

--- a/lib/active_remote/persistence.rb
+++ b/lib/active_remote/persistence.rb
@@ -241,6 +241,7 @@ module ActiveRemote
 
         response = rpc.execute(:create, new_attributes)
 
+        reset_attributes
         assign_attributes(response.to_hash)
         add_errors(response.errors) if response.respond_to?(:errors)
 
@@ -271,6 +272,7 @@ module ActiveRemote
 
         response = rpc.execute(:update, updated_attributes)
 
+        reset_attributes
         assign_attributes(response.to_hash)
         add_errors(response.errors) if response.respond_to?(:errors)
 

--- a/spec/lib/active_remote/attribute_assignment_spec.rb
+++ b/spec/lib/active_remote/attribute_assignment_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+describe ::ActiveRemote::AttributeAssignment do
+  let(:model_class) do
+    ::Class.new(::ActiveRemote::Base) do
+      attribute :name
+      attribute :address
+    end
+  end
+  subject { model_class.new }
+
+  describe "#reset_attributes" do
+    it "resets all attributes back to the default attribute hash" do
+      subject.assign_attributes(:name => "Testing", :address => "123 Yolo St")
+      expect(subject.attributes).to eq({"name" => "Testing", "address" => "123 Yolo St"})
+      subject.reset_attributes
+      expect(subject.attributes).to eq({"name" => nil, "address" => nil})
+    end
+  end
+end

--- a/spec/lib/active_remote/persistence_spec.rb
+++ b/spec/lib/active_remote/persistence_spec.rb
@@ -27,6 +27,16 @@ describe ::ActiveRemote::Persistence do
       value = Tag.create(:name => 'foo')
       expect(value).to be_a(Tag)
     end
+
+    context "when the server state changes" do
+      let(:response_without_errors) { ::HashWithIndifferentAccess.new(:errors => [], :user_guid => "123") }
+
+      it "uses the server state on create" do
+        tag = Tag.create({:name => "Ron", :user_guid => "456"})
+        expect(tag.name).to eq(nil)
+        expect(tag.user_guid).to eq("123")
+      end
+    end
   end
 
   describe ".create!" do
@@ -332,6 +342,16 @@ describe ::ActiveRemote::Persistence do
     it "saves the record" do
       expect(subject).to receive(:save)
       subject.update_attributes(attributes)
+    end
+
+    context "when the server state changes" do
+      let(:response_without_errors) { ::HashWithIndifferentAccess.new(:errors => [], :user_guid => "123") }
+
+      it "uses the server state on update" do
+        tag.update_attributes({:name => "Ron", :user_guid => "456"})
+        expect(tag.name).to eq(nil)
+        expect(tag.user_guid).to eq("123")
+      end
     end
   end
 


### PR DESCRIPTION
This adds a new `#reset_attributes` method which will reset the current state back to the `.default_attributes_hash`.

Then, we use the new reset attributes method to reset the state before assigning attributes from a response. In this case we expect the response to include an updated record containing all fields that would return from regular rpc search.

Why make this change?

Suppose the server always ignores writing an attribute, but the client
attempts to update this attribute anyway:

```
some_model.update(:the_server_ignores_this => true)
```

The correct behavior here should be to reset the
`:the_server_ignores_this` attribue back to `false` but that's not what
happens. The attribute will stay `true` because the server did not
explicitly set the value to `false`(it was omitted from the response), so the attribute was missing from
`response_proto.to_hash`.

But, with the new reset, we'll always refresh the model's state to
reflect the server. Always.

cc @liveh2o @brianstien @abrandoned @mattnichols 