### PR TITLE
accomodate booleans in the boolean typecaster

### DIFF
--- a/lib/active_remote/typecasting/boolean_typecaster.rb
+++ b/lib/active_remote/typecasting/boolean_typecaster.rb
@@ -1,9 +1,12 @@
 module ActiveRemote
   module Typecasting
     class BooleanTypecaster
-       FALSE_VALUES = ["n", "N", "no", "No", "NO", "false", "False", "FALSE", "off", "Off", "OFF", "f", "F"]
+      BOOL_VALUES = [true, false].freeze
+      FALSE_VALUES = ["n", "N", "no", "No", "NO", "false", "False", "FALSE", "off", "Off", "OFF", "f", "F"]
 
       def self.call(value)
+        return value if BOOL_VALUES.include?(value)
+
         case value
         when *FALSE_VALUES then false
         when Numeric, /^\-?[0-9]/ then !value.to_f.zero?


### PR DESCRIPTION
The boolean typecaster doesn't accommodate the idea of using a boolean (which protobuf does); so the inflation of a boolean is quite slow; below is the current version vs a new version with a mix of string/bool typecasting going on

```
Warming up --------------------------------------
 today (with string)    91.621k i/100ms
   new (with string)   216.747k i/100ms
   today (with bool)    80.029k i/100ms
     new (with bool)   264.165k i/100ms
Calculating -------------------------------------
 today (with string)      1.280M (± 2.8%) i/s -      6.413M in   5.016057s
   new (with string)      5.192M (± 5.5%) i/s -     26.010M in   5.028266s
   today (with bool)      1.055M (± 2.4%) i/s -      5.282M in   5.009922s
     new (with bool)      9.558M (± 7.9%) i/s -     47.550M in   5.014103s
```

@liveh2o 