### PR TITLE
Add support for registering types

### DIFF
--- a/lib/active_remote/attribute_definition.rb
+++ b/lib/active_remote/attribute_definition.rb
@@ -1,3 +1,5 @@
+require "active_remote/type"
+
 module ActiveRemote
   # Represents an attribute for reflection
   #
@@ -47,15 +49,17 @@ module ActiveRemote
     #   AttributeDefinition.new(:amount)
     #
     # @param [Symbol, String, #to_sym] name attribute name
+    # @param [Symbol] type attribute type
     # @param [Hash{Symbol => Object}] options attribute options
     #
     # @return [ActiveAttr::AttributeDefinition]
     #
     # @since 0.2.0
-    def initialize(name, options={})
+    def initialize(name, type = :unknown, **options)
       raise TypeError, "can't convert #{name.class} into Symbol" unless name.respond_to? :to_sym
       @name = name.to_sym
       @options = options
+      @options[:typecaster] = ::ActiveRemote::Type.lookup(type) unless type == :unknown
 
       if @options[:type]
         typecaster = ::ActiveRemote::Typecasting::TYPECASTER_MAP[@options[:type]]
@@ -101,6 +105,6 @@ module ActiveRemote
 
     # The attribute options
     # @since 0.5.0
-    attr_reader :options
+    attr_reader :options, :type
   end
 end

--- a/lib/active_remote/serializers/protobuf.rb
+++ b/lib/active_remote/serializers/protobuf.rb
@@ -1,27 +1,31 @@
-require "active_remote/typecasting"
+require "active_remote/type"
 
 module ActiveRemote
   module Serializers
     module Protobuf
       extend ActiveSupport::Concern
 
-      TYPECASTER_MAP = {
-        ::Protobuf::Field::BoolField     => ActiveRemote::Typecasting::BooleanTypecaster,
-        ::Protobuf::Field::BytesField    => ActiveRemote::Typecasting::StringTypecaster,
-        ::Protobuf::Field::DoubleField   => ActiveRemote::Typecasting::FloatTypecaster,
-        ::Protobuf::Field::Fixed32Field  => ActiveRemote::Typecasting::IntegerTypecaster,
-        ::Protobuf::Field::Fixed64Field  => ActiveRemote::Typecasting::IntegerTypecaster,
-        ::Protobuf::Field::FloatField    => ActiveRemote::Typecasting::FloatTypecaster,
-        ::Protobuf::Field::Int32Field    => ActiveRemote::Typecasting::IntegerTypecaster,
-        ::Protobuf::Field::Int64Field    => ActiveRemote::Typecasting::IntegerTypecaster,
-        ::Protobuf::Field::Sfixed32Field => ActiveRemote::Typecasting::IntegerTypecaster,
-        ::Protobuf::Field::Sfixed64Field => ActiveRemote::Typecasting::IntegerTypecaster,
-        ::Protobuf::Field::Sint32Field   => ActiveRemote::Typecasting::IntegerTypecaster,
-        ::Protobuf::Field::Sint64Field   => ActiveRemote::Typecasting::IntegerTypecaster,
-        ::Protobuf::Field::StringField   => ActiveRemote::Typecasting::StringTypecaster,
-        ::Protobuf::Field::Uint32Field   => ActiveRemote::Typecasting::IntegerTypecaster,
-        ::Protobuf::Field::Uint64Field   => ActiveRemote::Typecasting::IntegerTypecaster
+      FIELD_TYPE_MAP = {
+        ::Protobuf::Field::BoolField => :boolean,
+        ::Protobuf::Field::BytesField => :string,
+        ::Protobuf::Field::DoubleField => :float,
+        ::Protobuf::Field::Fixed32Field => :float,
+        ::Protobuf::Field::Fixed64Field => :float,
+        ::Protobuf::Field::FloatField => :float,
+        ::Protobuf::Field::Int32Field => :integer,
+        ::Protobuf::Field::Int64Field => :integer,
+        ::Protobuf::Field::Sfixed32Field => :float,
+        ::Protobuf::Field::Sfixed64Field => :float,
+        ::Protobuf::Field::Sint32Field => :integer,
+        ::Protobuf::Field::Sint64Field => :integer,
+        ::Protobuf::Field::StringField => :string,
+        ::Protobuf::Field::Uint32Field => :integer,
+        ::Protobuf::Field::Uint64Field => :integer
       }
+
+      def self.type_name_for_field(field)
+        FIELD_TYPE_MAP[field.type_class]
+      end
 
       module ClassMethods
         def fields_from_attributes(message_class, attributes)
@@ -118,6 +122,10 @@ module ActiveRemote
           value.is_a?(Array) ? value : [ value ]
         end
 
+        def type_name
+          Serializers::Protobuf.type_name_for_field(field)
+        end
+
         def typecast(value)
           return value if value.nil?
 
@@ -129,7 +137,7 @@ module ActiveRemote
         end
 
         def typecaster
-          @typecaster ||= TYPECASTER_MAP[field.type_class]
+          @typecaster ||= Type.lookup(type_name)
         end
 
         def typecaster?

--- a/lib/active_remote/type.rb
+++ b/lib/active_remote/type.rb
@@ -1,0 +1,35 @@
+# Based on the type registry from Rails 5.0
+# https://github.com/rails/rails/blob/5-0-stable/activemodel/lib/active_model/type.rb
+#
+# TODO: Replace this with the Active Model type registry once Rails 4.2 support is dropped.
+#
+require "active_remote/type/registry"
+require "active_remote/typecasting"
+
+module ActiveRemote
+  module Type
+    @registry = Registry.new
+
+    class << self
+      attr_accessor :registry # :nodoc:
+
+      # Add a new type to the registry, allowing it to be gotten through ActiveRemote::Type#lookup
+      def register(type_name, klass)
+        registry.register(type_name, klass)
+      end
+
+      def lookup(type_name) # :nodoc:
+        registry.lookup(type_name)
+      end
+    end
+
+    register(:boolean, Typecasting::BooleanTypecaster)
+    register(:date, Typecasting::DateTypecaster)
+    register(:datetime, Typecasting::DateTimeTypecaster)
+    register(:decimal, Typecasting::BigDecimalTypecaster)
+    register(:float, Typecasting::FloatTypecaster)
+    register(:integer, Typecasting::IntegerTypecaster)
+    register(:object, Typecasting::ObjectTypecaster)
+    register(:string, Typecasting::StringTypecaster)
+  end
+end

--- a/lib/active_remote/type/registry.rb
+++ b/lib/active_remote/type/registry.rb
@@ -1,0 +1,45 @@
+module ActiveRemote
+  module Type
+    class Registry
+      attr_reader :registrations
+
+      def initialize
+        @registrations = []
+      end
+
+      def register(type_name, typecaster)
+        registrations << registration_klass.new(type_name, typecaster)
+      end
+
+      def lookup(symbol)
+        registration = find_registration(symbol)
+        raise ArgumentError, "Unknown type #{symbol.inspect}" unless registration
+
+        registration.typecaster
+      end
+
+    private
+
+      def registration_klass
+        Registration
+      end
+
+      def find_registration(symbol)
+        registrations.find { |r| r.matches?(symbol) }
+      end
+    end
+
+    class Registration
+      attr_reader :name, :typecaster
+
+      def initialize(name, typecaster)
+        @name = name
+        @typecaster = typecaster
+      end
+
+      def matches?(type_name)
+        type_name == name
+      end
+    end
+  end
+end

--- a/spec/support/models/typecasted_author.rb
+++ b/spec/support/models/typecasted_author.rb
@@ -1,8 +1,8 @@
 class TypecastedAuthor < ::ActiveRemote::Base
   attribute :guid, :type => String
   attribute :name, :typecaster => StringTypecaster
-  attribute :age, :type => Integer
+  attribute :age, :integer
   attribute :birthday, :type => DateTime
-  attribute :writes_fiction, :type => Boolean
-  attribute :net_sales, :type => Float
+  attribute :writes_fiction, :boolean
+  attribute :net_sales, :typecaster => FloatTypecaster
 end


### PR DESCRIPTION
In preparation for transitioning to Active Model 5.2, add support for registering types that can be used to define attributes without using the existing `:type` or `:typecaster` options:

```ruby
attribute :name, :string
```

The `:type` and `:typecaster` options still work, but this brings the interface for the attribute method inline with what it is in Active Model 5.2.

Additionally, update the Protobuf serializer to use the new type registry rather than maintaining a map of typecasters directly.