### PR TITLE
Fix unknown type error in Protobuf serializer

### DIFF
--- a/lib/active_remote/serializers/protobuf.rb
+++ b/lib/active_remote/serializers/protobuf.rb
@@ -137,6 +137,8 @@ module ActiveRemote
         end
 
         def typecaster
+          return nil if type_name.nil?
+
           @typecaster ||= Type.lookup(type_name)
         end
 

--- a/spec/lib/active_remote/serializers/protobuf_spec.rb
+++ b/spec/lib/active_remote/serializers/protobuf_spec.rb
@@ -83,6 +83,7 @@ describe ActiveRemote::Serializers::Protobuf::Field do
       it { typecasts(:string_field, string_value => '') }
       it { typecasts(:uint32_field, '0' => 0) }
       it { typecasts(:uint64_field, '0' => 0) }
+      it { typecasts(:enum_field, 0 => 0) }
     end
   end
 end

--- a/spec/support/definitions/serializer.proto
+++ b/spec/support/definitions/serializer.proto
@@ -1,4 +1,9 @@
 message Serializer {
+  enum Type {
+    DEFAULT = 0;
+    USER = 1;
+  }
+
   optional bool bool_field         = 1;
   optional bytes bytes_field       = 2;
   optional double double_field     = 3;
@@ -14,4 +19,5 @@ message Serializer {
   optional string string_field     = 13;
   optional uint32 uint32_field     = 14;
   optional uint64 uint64_field     = 15;
+  optional Type enum_field         = 16;
 }

--- a/spec/support/protobuf/serializer.pb.rb
+++ b/spec/support/protobuf/serializer.pb.rb
@@ -9,7 +9,14 @@ require 'protobuf'
 ##
 # Message Classes
 #
-class Serializer < ::Protobuf::Message; end
+class Serializer < ::Protobuf::Message
+  class Type < ::Protobuf::Enum
+    define :DEFAULT, 0
+    define :USER, 1
+  end
+
+end
+
 
 
 ##
@@ -31,5 +38,6 @@ class Serializer
   optional :string, :string_field, 13
   optional :uint32, :uint32_field, 14
   optional :uint64, :uint64_field, 15
+  optional ::Serializer::Type, :enum_field, 16
 end
 


### PR DESCRIPTION
Previously, the Protobuf serializer would gracefully handle values that had no explicit typecaster. That unexpectedly changed with the latest release, resulting an in an unknown type error being thrown for Protobuf fields without explicit corresponding Ruby types (i.e., enums, messages).

Update the Protobuf serializer to restore the previous behavior, along with specs to ensure it doesn't happen again.