### PR TITLE
Make query attributes more permissive

### DIFF
--- a/lib/active_remote/query_attributes.rb
+++ b/lib/active_remote/query_attributes.rb
@@ -28,11 +28,7 @@ module ActiveRemote
       when true        then true
       when false, nil  then false
       else
-        if value.respond_to?(:zero?)
-          !value.zero?
-        else
-          value.present?
-        end
+        value.present?
       end
     end
 

--- a/spec/lib/active_remote/query_attribute_spec.rb
+++ b/spec/lib/active_remote/query_attribute_spec.rb
@@ -38,9 +38,10 @@ describe ::ActiveRemote::QueryAttributes do
       expect(subject.name?).to eq true
     end
 
-    it "is false when the attribute is 0" do
+    # This behavior varies from ActiveRecord, so we test it explicitly
+    it "is true when the attribute is 0" do
       subject.name = 0
-      expect(subject.name?).to eq false
+      expect(subject.name?).to eq true
     end
 
     it "is true when the attribute is 1" do


### PR DESCRIPTION
Active Record considers numeric values present only when `zero?` is false. This is incompatible with Protobuf enums since they are usually zero-based, but will also cause numeric values not to be sent over the wire when they are 0, 0.0, etc. This may be fine for AR, but doesn't work so well here in Active Remote.