### PR TITLE
Add ability to execute remote calls on current object

### DIFF
--- a/lib/active_remote/rpc.rb
+++ b/lib/active_remote/rpc.rb
@@ -52,6 +52,12 @@ module ActiveRemote
       end
     end
 
+    def assign_attributes_from_rpc(response)
+      new_attributes = self.class.build_from_rpc(response.to_hash)
+      @attributes.update(new_attributes)
+      add_errors(response.errors) if response.respond_to?(:errors)
+    end
+
     def remote_call(rpc_method, request_args)
       self.class.remote_call(rpc_method, request_args)
     end


### PR DESCRIPTION
Add a #remote method that executes a remote call on the current object and updates its attributes and errors from the response.

- Defaults request args to the scope key hash (e.g., guid: 'ABC-123') when none are given
- Returns false if the response contained errors; otherwise, returns true

This makes it much simpler to perform custom RPC actions that modify the remote record.

// @newellista