### PR TITLE
Include response errors in RemoteRecordNotSaved exception

### DIFF
--- a/lib/active_remote/errors.rb
+++ b/lib/active_remote/errors.rb
@@ -45,7 +45,7 @@ module ActiveRemote
   class RemoteRecordNotSaved < ActiveRemoteError
     attr_reader :record
 
-    def initialize(message_or_record)
+    def initialize(message_or_record = nil)
       message = message_or_record
       if message_or_record.is_a?(::ActiveRemote::Base)
         @record = message_or_record

--- a/lib/active_remote/errors.rb
+++ b/lib/active_remote/errors.rb
@@ -42,7 +42,17 @@ module ActiveRemote
 
   # Raised by ActiveRemove::Base.save! and ActiveRemote::Base.create! methods
   # when remote record cannot be saved because it is invalid.
-  class RemoteRecordNotSaved < RemoteRecordInvalid
+  class RemoteRecordNotSaved < ActiveRemoteError
+    attr_reader :record
+
+    def initialize(message_or_record)
+      message = message_or_record
+      if message_or_record.is_a?(::ActiveRemote::Base)
+        @record = message_or_record
+        message = @record.errors.full_messages.join(", ")
+      end
+      super(message)
+    end
   end
 
   class UnknownAttributeError < ActiveRemoteError

--- a/lib/active_remote/errors.rb
+++ b/lib/active_remote/errors.rb
@@ -42,7 +42,7 @@ module ActiveRemote
 
   # Raised by ActiveRemove::Base.save! and ActiveRemote::Base.create! methods
   # when remote record cannot be saved because it is invalid.
-  class RemoteRecordNotSaved < ActiveRemoteError
+  class RemoteRecordNotSaved < RemoteRecordInvalid
   end
 
   class UnknownAttributeError < ActiveRemoteError

--- a/lib/active_remote/persistence.rb
+++ b/lib/active_remote/persistence.rb
@@ -198,7 +198,7 @@ module ActiveRemote
     # Also runs any before/after save callbacks that are defined.
     #
     def save!(*args)
-      save(*args) || raise(RemoteRecordNotSaved)
+      save(*args) || fail(RemoteRecordNotSaved, self)
     end
 
     # Returns true if the record doesn't have errors; otherwise, returns false.

--- a/spec/lib/active_remote/errors_spec.rb
+++ b/spec/lib/active_remote/errors_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+describe ::ActiveRemote::RemoteRecordNotSaved do
+  let(:record) { ::Tag.new }
+
+  before do
+    record.errors[:base] << "Some error one!"
+    record.errors[:base] << "Some error two!"
+  end
+
+  context "when an active remote record is used" do
+    it "uses embedded errors in message" do
+      expect { fail(::ActiveRemote::RemoteRecordNotSaved, record) }
+        .to raise_error(ActiveRemote::RemoteRecordNotSaved, "Some error one!, Some error two!")
+    end
+  end
+
+  context "when a string is used" do
+    it "uses the string in the error message" do
+      expect { fail(::ActiveRemote::RemoteRecordNotSaved, "something bad happened") }
+        .to raise_error(ActiveRemote::RemoteRecordNotSaved, "something bad happened")
+    end
+  end
+
+  context "when no message is used" do
+    it "raises the error" do
+      expect { raise(::ActiveRemote::RemoteRecordNotSaved) }
+        .to raise_error(ActiveRemote::RemoteRecordNotSaved)
+    end
+  end
+end

--- a/spec/lib/active_remote/persistence_spec.rb
+++ b/spec/lib/active_remote/persistence_spec.rb
@@ -314,9 +314,16 @@ describe ::ActiveRemote::Persistence do
     end
 
     context "when the record is not saved" do
+      let(:errors) {
+        [Generic::Error.new(:field => "name", :message => "Error one!"),
+         Generic::Error.new(:field => "name", :message => "Error two!")]
+      }
+      let(:response) { Generic::Remote::Tag.new(:errors => errors) }
+      before { allow(rpc).to receive(:execute).and_return(response) }
+
       it "raises an exception" do
-        allow(subject).to receive(:save).and_return(false)
-        expect { subject.save! }.to raise_error(ActiveRemote::RemoteRecordNotSaved)
+        expect { subject.save! }
+          .to raise_error(ActiveRemote::RemoteRecordNotSaved, "Name Error one!, Name Error two!")
       end
     end
   end


### PR DESCRIPTION
This seems like a more correct behavior than: `ActiveRemote::RemoteRecordNotSaved: ActiveRemote::RemoteRecordNotSaved`.

cc @liveh2o 