### PR TITLE
do not update attributes when error occurs

### DIFF
--- a/active_remote.gemspec
+++ b/active_remote.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-pride", ">= 3.1.0"
   s.add_development_dependency "mad_rubocop"
   s.add_development_dependency "pry"
+  s.add_development_dependency "protobuf-nats"
   s.add_development_dependency "protobuf-rspec", ">= 1.1.2"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "benchmark-ips"

--- a/lib/active_remote/rpc.rb
+++ b/lib/active_remote/rpc.rb
@@ -53,8 +53,11 @@ module ActiveRemote
     end
 
     def assign_attributes_from_rpc(response)
-      new_attributes = self.class.build_from_rpc(response.to_hash)
-      @attributes.update(new_attributes)
+      unless response.respond_to?(:errors) && response.errors.count > 0
+        new_attributes = self.class.build_from_rpc(response.to_hash)
+        @attributes.update(new_attributes)
+      end
+
       add_errors(response.errors) if response.respond_to?(:errors)
     end
 

--- a/spec/lib/active_remote/rpc_spec.rb
+++ b/spec/lib/active_remote/rpc_spec.rb
@@ -53,7 +53,7 @@ describe ::ActiveRemote::RPC do
 
   describe "#assign_attributes_from_rpc" do
     let(:response) { ::Generic::Remote::Tag.new(:guid => tag.guid, :name => "bar") }
-    let(:tag) { ::Tag.new(:guid => SecureRandom.uuid) }
+    let(:tag) { ::Tag.new(:guid => SecureRandom.uuid, :name => "foo") }
 
     it "updates the attributes from the response" do
       expect { tag.assign_attributes_from_rpc(response) }.to change { tag.name }.to(response.name)
@@ -78,6 +78,12 @@ describe ::ActiveRemote::RPC do
 
       it "adds errors from the response" do
         expect { tag.assign_attributes_from_rpc(response) }.to change { tag.has_errors? }.to(true)
+      end
+
+      it "does not update attributes" do
+        expect(tag.name).to eq "foo"
+        tag.assign_attributes_from_rpc(response)
+        expect(tag.name).to eq "foo"
       end
     end
   end


### PR DESCRIPTION
Resolves https://github.com/liveh2o/active_remote/issues/78

In the event of an error on update, do not attempt to change the attributes.  Just append the errors.