### PR TITLE
check for existence of primary key is to_key

### DIFF
--- a/active_remote.gemspec
+++ b/active_remote.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-pride", ">= 3.1.0"
   s.add_development_dependency "mad_rubocop"
   s.add_development_dependency "pry"
+  s.add_development_dependency "protobuf-nats"
   s.add_development_dependency "protobuf-rspec", ">= 1.1.2"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "benchmark-ips"

--- a/lib/active_remote/primary_key.rb
+++ b/lib/active_remote/primary_key.rb
@@ -48,8 +48,8 @@ module ActiveRemote
     #   person = Person.new(1)
     #   person.to_key # => [1]
     def to_key
-      has_primary_key = respond_to?(primary_key.to_sym) && send(primary_key)
-      has_primary_key ? [send(primary_key)] : nil
+      @__to_key_key = respond_to?(primary_key) && send(primary_key) if @__to_key_key.nil?
+      @__to_key_key ? [@__to_key_key] : nil
     end
   end
 end

--- a/lib/active_remote/primary_key.rb
+++ b/lib/active_remote/primary_key.rb
@@ -48,7 +48,8 @@ module ActiveRemote
     #   person = Person.new(1)
     #   person.to_key # => [1]
     def to_key
-      send(primary_key) ? [send(primary_key)] : nil
+      has_primary_key = respond_to?(primary_key.to_sym) && send(primary_key)
+      has_primary_key ? [send(primary_key)] : nil
     end
   end
 end

--- a/spec/lib/active_remote/primary_key_spec.rb
+++ b/spec/lib/active_remote/primary_key_spec.rb
@@ -32,4 +32,18 @@ describe ActiveRemote::PrimaryKey do
       expect(Tag.new.primary_key).to eq Tag.primary_key
     end
   end
+
+  describe "#to_key" do
+    context "when no primary key is specified and default of guid does not exist" do
+      it "returns nil" do
+        expect(NoAttributes.new.to_key).to eq nil
+      end
+    end
+
+    context "when no primary key is specified, but default of guid exists" do
+      it "returns guid in array" do
+        expect(Tag.new(:guid => "TAG-123").to_key).to eq ["TAG-123"]
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/liveh2o/active_remote/issues/79

ActiveModel first checks to make sure that the primary key field responds to messages (see https://github.com/rails/rails/blob/5-2-stable/activemodel/lib/active_model/conversion.rb#L60), the same should probably happen here.