### PR TITLE
Add `find_by` to the Search module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ---
 language: ruby
 rvm:
-  - 2.3
+  - 2.5
   - jruby

--- a/lib/active_remote/search.rb
+++ b/lib/active_remote/search.rb
@@ -31,6 +31,23 @@ module ActiveRemote
         remote
       end
 
+      # Tries to load the first record; if it fails, returns nil.
+      #
+      # ====Examples
+      #
+      #   # A single hash
+      #   Tag.find_by(:guid => 'foo')
+      #
+      #   # Active remote object
+      #   Tag.find_by(Tag.new(:guid => 'foo'))
+      #
+      #   # Protobuf object
+      #   Tag.find_by(Generic::Remote::TagRequest.new(:guid => 'foo'))
+      #
+      def find_by(args)
+        self.search(args).first
+      end
+
       # Tries to load the first record; if it fails, then create is called
       # with the same arguments.
       #

--- a/spec/lib/active_remote/search_spec.rb
+++ b/spec/lib/active_remote/search_spec.rb
@@ -36,6 +36,33 @@ describe ActiveRemote::Search do
     end
   end
 
+  describe ".find_by" do
+    let(:args) { {} }
+    let(:record) { double(:record) }
+    let(:records) { [record] }
+
+    before { allow(Tag).to receive(:search).and_return(records) }
+
+    it "searches with the given args" do
+      expect(Tag).to receive(:search).with(args)
+      Tag.find_by(args)
+    end
+
+    context "when records are returned" do
+      it "returns the first record" do
+        expect(Tag.find_by(args)).to eq record
+      end
+    end
+
+    context "when no records are returned" do
+      before { allow(Tag).to receive(:search).and_return([]) }
+
+      it "returns nil" do
+        expect(Tag.find_by(args)).to be_nil
+      end
+    end
+  end
+
   describe ".search" do
     let(:serialized_records) { [Tag.instantiate(:guid => "123")] }
 


### PR DESCRIPTION
Currently we have `.search`, which returns a (possibly empty) array of results, and we have `.find`, which returns a single result or raises `ActiveRemote::RemoteRecordNotFound`. 

We see a common pattern when we know we need only one record, but we want `nil` instead of raising an error:
```
RemoteModel.search(:key => value).first
```

This MR proposes adding a `.find_by` method to ActiveRemote classes, which would allow us to instead write:
```
RemoteModel.find_by(:key => value)
```
The new method would be parallel to the ActiveRecord `.find_by` method.