### PR TITLE
Updates for Rails 6.1

### DIFF
--- a/active_remote.gemspec
+++ b/active_remote.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   ##
   # Dependencies
   #
-  s.add_dependency "activemodel", "~> 6.0.0"
-  s.add_dependency "activesupport", "~> 6.0.0"
+  s.add_dependency "activemodel", "~> 6.1.0"
+  s.add_dependency "activesupport", "~> 6.1.0"
   s.add_dependency "protobuf", ">= 3.0"
 
   ##

--- a/lib/active_remote/attribute_methods.rb
+++ b/lib/active_remote/attribute_methods.rb
@@ -12,8 +12,11 @@ module ActiveRemote
       attribute(name)
     end
 
-    def []=(name, value)
-      write_attribute(name, value)
+    def []=(attr_name, value)
+      name = attr_name.to_s
+      name = self.class.attribute_aliases[name] || name
+
+      @attributes.write_from_user(name, value)
     end
 
     # Returns an <tt>#inspect</tt>-like string for the value of the

--- a/lib/active_remote/integration.rb
+++ b/lib/active_remote/integration.rb
@@ -63,7 +63,7 @@ module ActiveRemote
       case
       when new_record? then
         "#{model_name.cache_key}/new"
-      when ::ActiveRemote.config.default_cache_key_updated_at? && (timestamp = self[:updated_at]) then
+      when ::ActiveRemote.config.default_cache_key_updated_at? && (timestamp = self.updated_at) then
         timestamp = timestamp.utc.to_s(self.class.cache_timestamp_format)
         "#{model_name.cache_key}/#{send(primary_key)}-#{timestamp}"
       else

--- a/lib/active_remote/integration.rb
+++ b/lib/active_remote/integration.rb
@@ -63,7 +63,7 @@ module ActiveRemote
       case
       when new_record? then
         "#{model_name.cache_key}/new"
-      when ::ActiveRemote.config.default_cache_key_updated_at? && (timestamp = self["updated_at"]) then
+      when ::ActiveRemote.config.default_cache_key_updated_at? && (self.respond_to?(:[]) && timestamp = self["updated_at"]) then
         timestamp = timestamp.utc.to_s(self.class.cache_timestamp_format)
         "#{model_name.cache_key}/#{send(primary_key)}-#{timestamp}"
       else

--- a/lib/active_remote/integration.rb
+++ b/lib/active_remote/integration.rb
@@ -63,7 +63,7 @@ module ActiveRemote
       case
       when new_record? then
         "#{model_name.cache_key}/new"
-      when ::ActiveRemote.config.default_cache_key_updated_at? && (timestamp = self.updated_at) then
+      when ::ActiveRemote.config.default_cache_key_updated_at? && (timestamp = self["updated_at"]) then
         timestamp = timestamp.utc.to_s(self.class.cache_timestamp_format)
         "#{model_name.cache_key}/#{send(primary_key)}-#{timestamp}"
       else


### PR DESCRIPTION
I had to tweak some code and I don't fully understand the changes in Rails that made it necessary, but what I do know is that the private `write_attribute` method for ActiveModel was removed. I replace it with the implementation it used to have, but I am wondering if there is a better way to do this that uses the public API instead of private stuff that is prone to change again on us.

The other issue I had was with the `cache_key` method in `integrations.rb`. For some reason `updated_at` has a string key instead of a symbol key, but I opted to simply call the attribute normally instead and that got the tests to pass that way.


Happy to make changes if there is a better way forward.