### PR TITLE
Updated for Rails 6.1 and Rails 7.

### DIFF
--- a/active_remote.gemspec
+++ b/active_remote.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   ##
   # Dependencies
   #
-  s.add_dependency "activemodel", ">= 6.1.0", "< 7.1.0"
-  s.add_dependency "activesupport", ">= 6.1.0", "< 7.1.0"
+  s.add_dependency "activemodel", ">= 6.1.0", "< 7.0.0"
+  s.add_dependency "activesupport", ">= 6.1.0", "< 7.0.0"
   s.add_dependency "protobuf", ">= 3.0"
 
   ##

--- a/active_remote.gemspec
+++ b/active_remote.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   ##
   # Dependencies
   #
-  s.add_dependency "activemodel", "~> 6.0.0"
-  s.add_dependency "activesupport", "~> 6.0.0"
+  s.add_dependency "activemodel", ">= 6.1.0", "< 7.1.0"
+  s.add_dependency "activesupport", ">= 6.1.0", "< 7.1.0"
   s.add_dependency "protobuf", ">= 3.0"
 
   ##

--- a/lib/active_remote/attribute_methods.rb
+++ b/lib/active_remote/attribute_methods.rb
@@ -8,12 +8,16 @@ module ActiveRemote
       end
     end
 
-    def [](name)
+    def [](attr_name)
+      name = attr_name.to_s
+      name = self.class.attribute_aliases[name] || name
       @attributes.fetch_value(name.to_s)
     end
 
-    def []=(name, value)
-      @attributes.write_from_user(name.to_s, value)
+    def []=(attr_name, value)
+      name = attr_name.to_s
+      name = self.class.attribute_aliases[name] || name
+      @attributes.write_from_user(name, value)
     end
 
     # Returns an <tt>#inspect</tt>-like string for the value of the

--- a/lib/active_remote/attribute_methods.rb
+++ b/lib/active_remote/attribute_methods.rb
@@ -9,11 +9,11 @@ module ActiveRemote
     end
 
     def [](name)
-      attribute(name.to_s)
+      @attributes.fetch_value(name.to_s)
     end
 
     def []=(name, value)
-      _write_attribute(name.to_s, value)
+      @attributes.write_from_user(name.to_s, value)
     end
 
     # Returns an <tt>#inspect</tt>-like string for the value of the

--- a/lib/active_remote/attribute_methods.rb
+++ b/lib/active_remote/attribute_methods.rb
@@ -9,11 +9,11 @@ module ActiveRemote
     end
 
     def [](name)
-      attribute(name)
+      attribute(name.to_s)
     end
 
     def []=(name, value)
-      write_attribute(name, value)
+      _write_attribute(name.to_s, value)
     end
 
     # Returns an <tt>#inspect</tt>-like string for the value of the

--- a/spec/lib/active_remote/errors_spec.rb
+++ b/spec/lib/active_remote/errors_spec.rb
@@ -4,8 +4,8 @@ describe ::ActiveRemote::RemoteRecordNotSaved do
   let(:record) { ::Tag.new }
 
   before do
-    record.errors[:base] << "Some error one!"
-    record.errors[:base] << "Some error two!"
+    record.errors.add(:base, :invalid, :message => "Some error one!")
+    record.errors.add(:base, :invalid, :message => "Some error two!")
   end
 
   context "when an active remote record is used" do

--- a/spec/lib/active_remote/persistence_spec.rb
+++ b/spec/lib/active_remote/persistence_spec.rb
@@ -148,7 +148,7 @@ describe ::ActiveRemote::Persistence do
     end
 
     context "when errors are present" do
-      before { subject.errors[:base] << "Boom!" }
+      before { subject.errors.add(:base, :invalid, :message => "Boom!") }
 
       its(:has_errors?) { should be_truthy }
     end
@@ -295,7 +295,7 @@ describe ::ActiveRemote::Persistence do
     end
 
     context "when the record has errors before the save" do
-      before { subject.errors[:base] << "Boom!" }
+      before { subject.errors.add(:base, :invalid, :message => "Boom!") }
 
       it "clears the errors before the save" do
         expect(subject.errors).not_to be_empty
@@ -330,7 +330,7 @@ describe ::ActiveRemote::Persistence do
 
   describe "#success?" do
     context "when errors are present" do
-      before { subject.errors[:base] << "Boom!" }
+      before { subject.errors.add(:base, :invalid, :message => "Boom!") }
 
       its(:success?) { should be_falsey }
     end


### PR DESCRIPTION
It looks like (at least in Rails 7) that attributes need to be called with strings and not keys.
Also calling `subject.errors[:base] << "Boom!"` looks like it's deprecated in favor of `subject.errors.add(:base, :foo, message: "Boom!")`