### PR TITLE
revert the reader and writer methods so they can be overidden

### DIFF
--- a/lib/active_remote/attribute_methods.rb
+++ b/lib/active_remote/attribute_methods.rb
@@ -11,13 +11,15 @@ module ActiveRemote
     def [](attr_name)
       name = attr_name.to_s
       name = self.class.attribute_aliases[name] || name
-      @attributes.fetch_value(name.to_s)
+
+      attribute(name.to_s)
     end
 
     def []=(attr_name, value)
       name = attr_name.to_s
       name = self.class.attribute_aliases[name] || name
-      @attributes.write_from_user(name, value)
+
+      _write_attribute(name.to_s, value)
     end
 
     # Returns an <tt>#inspect</tt>-like string for the value of the

--- a/lib/active_remote/attribute_methods.rb
+++ b/lib/active_remote/attribute_methods.rb
@@ -11,14 +11,12 @@ module ActiveRemote
     def [](attr_name)
       name = attr_name.to_s
       name = self.class.attribute_aliases[name] || name
-
       attribute(name.to_s)
     end
 
     def []=(attr_name, value)
       name = attr_name.to_s
       name = self.class.attribute_aliases[name] || name
-
       _write_attribute(name.to_s, value)
     end
 


### PR DESCRIPTION
In order to be able to override `_write_attribute` we should not duplicate the logic but call the existing logic.