### PR TITLE
Standardize

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,6 +16,15 @@ on:
     branches: [master]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+          bundler-cache: true
+      - run: bundle exec standardrb --parallel --format github
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,28 +1,3 @@
-# Styles are inherited from Mad Rubocop
-
+---
 inherit_gem:
-  mad_rubocop: .rubocop.yml
-
-# Styles that are modified from the defaults
-AllCops:
-  TargetRubyVersion: 3.1
-  Exclude:
-    - "**/*.pb.rb"
-
-Style/BlockDelimiters:
-  Description: >-
-                Avoid using {...} for multi-line blocks (multiline chaining is always ugly).
-                Prefer {...} over do...end for single-line blocks.
-  Exclude:
-    - "spec/**/*"
-
-Style/HashSyntax:
-  Description: >-
-                 Prefer Ruby 1.8 hash syntax { :a => 1, :b => 2 } over 1.9 syntax { a: 1, b: 2 }.
-  EnforcedStyle: hash_rockets
-  Exclude:
-    - "Gemfile"
-
-Layout/SpaceAroundOperators:
-  Exclude:
-    - "*.gemspec"
+  standard: config/ruby-3.1.yml

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,2 @@
+parallel: true # default: false
+format: progress # default: Standard::Formatter

--- a/Rakefile
+++ b/Rakefile
@@ -2,16 +2,13 @@
 require "bundler/gem_tasks"
 require "protobuf/tasks"
 require "rspec/core/rake_task"
-require "rubocop/rake_task"
-
-desc "Run cops"
-::RuboCop::RakeTask.new(:rubocop)
+require "standard/rake"
 
 desc "Run specs"
 ::RSpec::Core::RakeTask.new(:spec)
 
 desc "Run cops and specs (default)"
-task :default => [:rubocop, :spec]
+task default: [:standard, :spec]
 
 desc "Remove protobuf definitions that have been compiled"
 task :clean do

--- a/active_remote.gemspec
+++ b/active_remote.gemspec
@@ -1,20 +1,17 @@
-# -*- encoding: utf-8 -*-
-
 $LOAD_PATH.push File.expand_path("lib", __dir__)
 require "active_remote/version"
 
 Gem::Specification.new do |s|
-  s.name          = "active_remote"
-  s.version       = ActiveRemote::VERSION
-  s.authors       = ["Adam Hutchison"]
-  s.email         = ["liveh2o@gmail.com"]
-  s.homepage      = "https://github.com/liveh2o/active_remote"
-  s.summary       = "Active Record for your platform"
-  s.description   = "Active Remote provides Active Record-like object-relational mapping over RPC. It was written for use with Google Protocol Buffers, but could be extended to use any RPC data format."
+  s.name = "active_remote"
+  s.version = ActiveRemote::VERSION
+  s.authors = ["Adam Hutchison"]
+  s.email = ["liveh2o@gmail.com"]
+  s.homepage = "https://github.com/liveh2o/active_remote"
+  s.summary = "Active Record for your platform"
+  s.description = "Active Remote provides Active Record-like object-relational mapping over RPC. It was written for use with Google Protocol Buffers, but could be extended to use any RPC data format."
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
+  s.files = `git ls-files`.split("\n")
+  s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
   s.required_ruby_version = ">= 2.7.0"
@@ -29,13 +26,13 @@ Gem::Specification.new do |s|
   ##
   # Development Dependencies
   #
-  s.add_development_dependency "rake"
-  s.add_development_dependency "rspec", ">= 3.3.0"
+  s.add_development_dependency "benchmark-ips"
+  s.add_development_dependency "protobuf-rspec", ">= 1.1.2"
+  s.add_development_dependency "pry"
   s.add_development_dependency "rspec-its"
   s.add_development_dependency "rspec-pride", ">= 3.1.0"
-  s.add_development_dependency "mad_rubocop"
-  s.add_development_dependency "pry"
-  s.add_development_dependency "protobuf-rspec", ">= 1.1.2"
+  s.add_development_dependency "rspec", ">= 3.3.0"
   s.add_development_dependency "simplecov"
-  s.add_development_dependency "benchmark-ips"
+  s.add_development_dependency "standard"
+  s.add_development_dependency "rake"
 end

--- a/lib/active_remote/association.rb
+++ b/lib/active_remote/association.rb
@@ -131,10 +131,10 @@ module ActiveRemote
         raise "Could not find attribute: '#{options[:scope]}' on #{associated_class}" unless associated_class.public_instance_methods.include?(options[:scope])
       end
 
-    private
+      private
 
       def create_association_writer(associated_klass, options = {})
-        define_method("#{associated_klass}=") do |new_value|
+        define_method(:"#{associated_klass}=") do |new_value|
           raise "New value must be an array" if options[:has_many] == true && new_value.class != Array
 
           instance_variable_set(:"@#{associated_klass}", new_value)
@@ -156,7 +156,7 @@ module ActiveRemote
             instance_variable_set(:"@#{associated_klass}", value)
           end
 
-          return value
+          value
         end
 
         create_association_writer(associated_klass, options)

--- a/lib/active_remote/base.rb
+++ b/lib/active_remote/base.rb
@@ -43,7 +43,7 @@ module ActiveRemote
     include ::ActiveRemote::Validations
     include ::ActiveModel::Validations::Callbacks
 
-    define_model_callbacks :initialize, :only => :after
+    define_model_callbacks :initialize, only: :after
 
     def initialize(attributes = {})
       super
@@ -107,23 +107,23 @@ module ActiveRemote
       # We check defined?(@attributes) not to issue warnings if the object is
       # allocated but not initialized.
       inspection = if defined?(@attributes) && @attributes
-                     attribute_names.collect do |name, _|
-                       if attribute?(name)
-                         "#{name}: #{attribute_for_inspect(name)}"
-                       else
-                         name
-                       end
-                     end.compact.join(", ")
-                   else
-                     "not initialized"
-                   end
+        attribute_names.collect do |name, _|
+          if attribute?(name)
+            "#{name}: #{attribute_for_inspect(name)}"
+          else
+            name
+          end
+        end.compact.join(", ")
+      else
+        "not initialized"
+      end
 
       "#<#{self.class} #{inspection}>"
     end
 
     # Returns a hash of the given methods with their names as keys and returned values as values.
     def slice(*methods)
-      Hash[methods.flatten.map! { |method| [method, public_send(method)] }].with_indifferent_access
+      methods.flatten.map! { |method| [method, public_send(method)] }.to_h.with_indifferent_access
     end
   end
 

--- a/lib/active_remote/dirty.rb
+++ b/lib/active_remote/dirty.rb
@@ -62,7 +62,7 @@ module ActiveRemote
       enable_dirty_tracking
     end
 
-  private
+    private
 
     # Wether or not changes are currently being tracked for this class.
     #
@@ -74,7 +74,7 @@ module ActiveRemote
     # ActiveModel::Dirty.
     #
     def attribute=(name, value)
-      send("#{name}_will_change!") if _active_remote_track_changes? && value != self[name]
+      send(:"#{name}_will_change!") if _active_remote_track_changes? && value != self[name]
       super
     end
 

--- a/lib/active_remote/dsl.rb
+++ b/lib/active_remote/dsl.rb
@@ -20,32 +20,32 @@ module ActiveRemote
       end
 
       def endpoint_for_create(endpoint)
-        endpoints :create => endpoint
+        endpoints create: endpoint
       end
 
       def endpoint_for_delete(endpoint)
-        endpoints :delete => endpoint
+        endpoints delete: endpoint
       end
 
       def endpoint_for_destroy(endpoint)
-        endpoints :destroy => endpoint
+        endpoints destroy: endpoint
       end
 
       def endpoint_for_search(endpoint)
-        endpoints :search => endpoint
+        endpoints search: endpoint
       end
 
       def endpoint_for_update(endpoint)
-        endpoints :update => endpoint
+        endpoints update: endpoint
       end
 
       def endpoints(endpoints_hash = nil)
         @endpoints ||= {
-          :create => :create,
-          :delete => :delete,
-          :destroy => :destroy,
-          :search => :search,
-          :update => :update
+          create: :create,
+          delete: :delete,
+          destroy: :destroy,
+          search: :search,
+          update: :update
         }
         @endpoints.merge!(endpoints_hash) if endpoints_hash.present?
         @endpoints
@@ -114,7 +114,7 @@ module ActiveRemote
         @service_name ||= _determine_service_name
       end
 
-    private
+      private
 
       # Combine the namespace and service values, constantize them and return
       # the class constant.
@@ -127,12 +127,12 @@ module ActiveRemote
       end
 
       def _determine_service_name
-        underscored_name = self.name.underscore
-        "#{underscored_name}_service".to_sym
+        underscored_name = name.underscore
+        :"#{underscored_name}_service"
       end
     end
 
-  private
+    private
 
     # Private convenience methods for accessing DSL methods in instances
     #

--- a/lib/active_remote/integration.rb
+++ b/lib/active_remote/integration.rb
@@ -9,7 +9,7 @@ module ActiveRemote
       # versioning is off. Accepts any of the symbols in <tt>Time::DATE_FORMATS</tt>.
       #
       # This is +:usec+, by default.
-      class_attribute :cache_timestamp_format, :instance_writer => false, :default => :usec
+      class_attribute :cache_timestamp_format, instance_writer: false, default: :usec
 
       ##
       # :singleton-method:
@@ -17,7 +17,7 @@ module ActiveRemote
       # by a changing version in the #cache_version method.
       #
       # This is +false+, by default until Rails 6.0.
-      class_attribute :cache_versioning, :instance_writer => false, :default => false
+      class_attribute :cache_versioning, instance_writer: false, default: false
     end
 
     # Returns a +String+, which Action Pack uses for constructing a URL to this
@@ -60,10 +60,10 @@ module ActiveRemote
     #   Person.find(5).cache_key  # => "people/5-20071224150000" (updated_at available)
     #
     def cache_key
-      case
-      when new_record? then
+      if new_record?
+
         "#{model_name.cache_key}/new"
-      when ::ActiveRemote.config.default_cache_key_updated_at? && (self.respond_to?(:[]) && timestamp = self["updated_at"]) then
+      elsif ::ActiveRemote.config.default_cache_key_updated_at? && (respond_to?(:[]) && (timestamp = self["updated_at"]))
         timestamp = timestamp.utc.to_fs(self.class.cache_timestamp_format)
         "#{model_name.cache_key}/#{send(primary_key)}-#{timestamp}"
       else
@@ -123,8 +123,8 @@ module ActiveRemote
         else
           define_method :to_param do
             if (default = super()) &&
-               (result = send(method_name).to_s).present? &&
-               (param = result.squish.parameterize.truncate(20, :separator => /-/, :omission => "")).present?
+                (result = send(method_name).to_s).present? &&
+                (param = result.squish.parameterize.truncate(20, separator: /-/, omission: "")).present?
               "#{default}-#{param}"
             else
               default

--- a/lib/active_remote/persistence.rb
+++ b/lib/active_remote/persistence.rb
@@ -28,7 +28,7 @@ module ActiveRemote
       # The newly created record is returned if it was successfully saved or not.
       #
       def create(attributes)
-        remote = self.new(attributes)
+        remote = new(attributes)
         remote.save
         remote
       end
@@ -40,7 +40,7 @@ module ActiveRemote
       # an ActiveRemote::RemoteRecordNotSaved exception.
       #
       def create!(attributes)
-        remote = self.new(attributes)
+        remote = new(attributes)
         remote.save!
         remote
       end
@@ -49,8 +49,8 @@ module ActiveRemote
       # when retrieving records that already exist, so @new_record is set to false.
       #
       def instantiate(new_attributes = {}, options = {})
-        attributes = self.build_from_rpc(new_attributes)
-        new_object = self.allocate.init_with(attributes)
+        attributes = build_from_rpc(new_attributes)
+        new_object = allocate.init_with(attributes)
         new_object.readonly! if options[:readonly]
 
         new_object
@@ -220,8 +220,8 @@ module ActiveRemote
       raise ReadOnlyRemoteRecord if readonly?
 
       name = name.to_s
-      send("#{name}=", value)
-      save(:validate => false)
+      send(:"#{name}=", value)
+      save(validate: false)
     end
 
     # Updates the attributes of the remote record from the passed-in hash and
@@ -244,7 +244,7 @@ module ActiveRemote
     end
     alias_method :update!, :update_attributes!
 
-  private
+    private
 
     # Handles creating a remote object and serializing it's attributes and
     # errors from the response.

--- a/lib/active_remote/query_attributes.rb
+++ b/lib/active_remote/query_attributes.rb
@@ -25,14 +25,14 @@ module ActiveRemote
       value = self[attr_name]
 
       case value
-      when true        then true
-      when false, nil  then false
+      when true then true
+      when false, nil then false
       else
         value.present?
       end
     end
 
-  private
+    private
 
     def attribute?(attribute_name)
       query_attribute(attribute_name)

--- a/lib/active_remote/rpc.rb
+++ b/lib/active_remote/rpc.rb
@@ -15,9 +15,8 @@ module ActiveRemote
       def build_from_rpc(values)
         values = values.stringify_keys
 
-        attribute_names.inject(_default_attributes.deep_dup) do |attributes, name|
+        attribute_names.each_with_object(_default_attributes.deep_dup) do |name, attributes|
           attributes.write_from_database(name, values[name])
-          attributes
         end
       end
 

--- a/lib/active_remote/rpc_adapters/protobuf_adapter.rb
+++ b/lib/active_remote/rpc_adapters/protobuf_adapter.rb
@@ -8,7 +8,7 @@ module ActiveRemote
       attr_reader :service_class
       attr_accessor :endpoints
 
-      delegate :client, :to => :service_class
+      delegate :client, to: :service_class
 
       ##
       # Constructor!
@@ -41,7 +41,7 @@ module ActiveRemote
         response
       end
 
-    private
+      private
 
       # Return a protobuf request object for the given rpc request.
       #

--- a/lib/active_remote/search.rb
+++ b/lib/active_remote/search.rb
@@ -25,7 +25,7 @@ module ActiveRemote
       #   Tag.find(Generic::Remote::TagRequest.new(:guid => 'foo'))
       #
       def find(args)
-        remote = self.search(args).first
+        remote = search(args).first
         raise RemoteRecordNotFound, self if remote.nil?
 
         remote
@@ -45,7 +45,7 @@ module ActiveRemote
       #   Tag.find_by(Generic::Remote::TagRequest.new(:guid => 'foo'))
       #
       def find_by(args)
-        self.search(args).first
+        search(args).first
       end
 
       # Tries to load the first record; if it fails, then create is called
@@ -60,8 +60,8 @@ module ActiveRemote
       #   Tag.first_or_create(Generic::Remote::TagRequest.new(:name => 'foo'))
       #
       def first_or_create(attributes)
-        remote = self.search(attributes).first
-        remote ||= self.create(attributes)
+        remote = search(attributes).first
+        remote ||= create(attributes)
         remote
       end
 
@@ -69,8 +69,8 @@ module ActiveRemote
       # with the same arguments.
       #
       def first_or_create!(attributes)
-        remote = self.search(attributes).first
-        remote ||= self.create!(attributes)
+        remote = search(attributes).first
+        remote ||= create!(attributes)
         remote
       end
 
@@ -86,8 +86,8 @@ module ActiveRemote
       #   Tag.first_or_initialize(Generic::Remote::TagRequest.new(:name => 'foo'))
       #
       def first_or_initialize(attributes)
-        remote = self.search(attributes).first
-        remote ||= self.new(attributes)
+        remote = search(attributes).first
+        remote ||= new(attributes)
         remote
       end
 
@@ -134,7 +134,7 @@ module ActiveRemote
     #
     def reload
       fresh_object = self.class.find(scope_key_hash)
-      @attributes = fresh_object.instance_variable_get("@attributes")
+      @attributes = fresh_object.instance_variable_get(:@attributes)
       self
     end
   end

--- a/lib/active_remote/serializers/protobuf.rb
+++ b/lib/active_remote/serializers/protobuf.rb
@@ -50,7 +50,7 @@ module ActiveRemote
         # Class methods
         #
         def self.from_attributes(message_class, attributes)
-          fields = self.new(message_class, attributes)
+          fields = new(message_class, attributes)
           fields.from_attributes
         end
 
@@ -58,12 +58,11 @@ module ActiveRemote
         # Instance methods
         #
         def from_attributes
-          attributes.inject({}) do |hash, (key, value)|
+          attributes.each_with_object({}) do |(key, value), hash|
             field = message_class.get_field(key, true) # Check extension fields, too
             value = Field.from_attribute(field, value) if field
 
             hash[key] = value
-            hash
           end
         end
       end
@@ -83,7 +82,7 @@ module ActiveRemote
         # Class methods
         #
         def self.from_attribute(field, value)
-          field = self.new(field, value)
+          field = new(field, value)
           field.from_attribute
         end
 
@@ -91,19 +90,21 @@ module ActiveRemote
         # Instance methods
         #
         def from_attribute
-          case
-          when field.repeated_message? then
+          if field.repeated_message?
+
             repeated_message_value
-          when field.message? then
+          elsif field.message?
+
             message_value
-          when field.repeated? then
+          elsif field.repeated?
+
             repeated_value.map { |value| cast(value) }
           else
             cast_value
           end
         end
 
-      private
+        private
 
         def cast(value)
           type.cast(value)

--- a/lib/active_remote/validations.rb
+++ b/lib/active_remote/validations.rb
@@ -45,13 +45,13 @@ module ActiveRemote
     #
     def valid?(context = nil)
       context ||= (new_record? ? :create : :update)
-      output = super(context)
+      output = super
       errors.empty? && output
     end
 
     alias_method :validate, :valid?
 
-  protected
+    protected
 
     def raise_validation_error
       fail ActiveRemote::RemoteRecordInvalid, self

--- a/spec/lib/active_remote/association_spec.rb
+++ b/spec/lib/active_remote/association_spec.rb
@@ -9,18 +9,18 @@ describe ActiveRemote::Association do
       let(:author_guid) { "AUT-123" }
       let(:user_guid) { "USR-123" }
       let(:default_category_guid) { "CAT-123" }
-      subject { Post.new(:author_guid => author_guid, :user_guid => user_guid) }
+      subject { Post.new(author_guid: author_guid, user_guid: user_guid) }
 
       it { is_expected.to respond_to(:author) }
       it { is_expected.to respond_to(:author=) }
 
       it "searches the associated model for a single record" do
-        expect(Author).to receive(:search).with({:guid => subject.author_guid}).and_return(records)
+        expect(Author).to receive(:search).with({guid: subject.author_guid}).and_return(records)
         expect(subject.author).to eq record
       end
 
       it "memoizes the result record" do
-        expect(Author).to receive(:search).once.with({:guid => subject.author_guid}).and_return(records)
+        expect(Author).to receive(:search).once.with({guid: subject.author_guid}).and_return(records)
         3.times { expect(subject.author).to eq record }
       end
 
@@ -34,7 +34,7 @@ describe ActiveRemote::Association do
 
       context "when the search is empty" do
         it "returns a nil" do
-          expect(Author).to receive(:search).with({:guid => subject.author_guid}).and_return([])
+          expect(Author).to receive(:search).with({guid: subject.author_guid}).and_return([])
           expect(subject.author).to be_nil
         end
       end
@@ -43,7 +43,7 @@ describe ActiveRemote::Association do
         it { is_expected.to respond_to(:user) }
 
         it "searches the associated model for multiple records" do
-          expect(Author).to receive(:search).with({:guid => subject.author_guid, :user_guid => subject.user_guid}).and_return(records)
+          expect(Author).to receive(:search).with({guid: subject.author_guid, user_guid: subject.user_guid}).and_return(records)
           expect(subject.user).to eq(record)
         end
 
@@ -68,16 +68,16 @@ describe ActiveRemote::Association do
     context "specific association with class name" do
       let(:author_guid) { "AUT-456" }
 
-      subject { Post.new(:author_guid => author_guid) }
+      subject { Post.new(author_guid: author_guid) }
       it { is_expected.to respond_to(:coauthor) }
 
       it "searches the associated model for a single record" do
-        expect(Author).to receive(:search).with({:guid => subject.author_guid}).and_return(records)
+        expect(Author).to receive(:search).with({guid: subject.author_guid}).and_return(records)
         expect(subject.coauthor).to eq record
       end
 
       it "creates a setter method" do
-        author = Author.new(:guid => author_guid)
+        author = Author.new(guid: author_guid)
         subject.coauthor = author
         expect(subject.coauthor).to eq(author)
       end
@@ -86,11 +86,11 @@ describe ActiveRemote::Association do
     context "specific association with class name and foreign_key" do
       let(:author_guid) { "AUT-456" }
 
-      subject { Post.new(:bestseller_guid => author_guid) }
+      subject { Post.new(bestseller_guid: author_guid) }
       it { is_expected.to respond_to(:bestseller) }
 
       it "searches the associated model for a single record" do
-        expect(Author).to receive(:search).with({:guid => subject.bestseller_guid}).and_return(records)
+        expect(Author).to receive(:search).with({guid: subject.bestseller_guid}).and_return(records)
         expect(subject.bestseller).to eq record
       end
     end
@@ -101,18 +101,18 @@ describe ActiveRemote::Association do
     let(:guid) { "AUT-123" }
     let(:user_guid) { "USR-123" }
 
-    subject { Author.new(:guid => guid, :user_guid => user_guid) }
+    subject { Author.new(guid: guid, user_guid: user_guid) }
 
     it { is_expected.to respond_to(:posts) }
     it { is_expected.to respond_to(:posts=) }
 
     it "searches the associated model for all associated records" do
-      expect(Post).to receive(:search).with({:author_guid => subject.guid}).and_return(records)
+      expect(Post).to receive(:search).with({author_guid: subject.guid}).and_return(records)
       expect(subject.posts).to eq records
     end
 
     it "memoizes the result record" do
-      expect(Post).to receive(:search).once.with({:author_guid => subject.guid}).and_return(records)
+      expect(Post).to receive(:search).once.with({author_guid: subject.guid}).and_return(records)
       3.times { expect(subject.posts).to eq records }
     end
 
@@ -126,7 +126,7 @@ describe ActiveRemote::Association do
 
     context "when the search is empty" do
       it "returns the empty set" do
-        expect(Post).to receive(:search).with({:author_guid => subject.guid}).and_return([])
+        expect(Post).to receive(:search).with({author_guid: subject.guid}).and_return([])
         expect(subject.posts).to be_empty
       end
     end
@@ -135,7 +135,7 @@ describe ActiveRemote::Association do
       it { is_expected.to respond_to(:flagged_posts) }
 
       it "searches the associated model for a single record" do
-        expect(Post).to receive(:search).with({:author_guid => subject.guid}).and_return([])
+        expect(Post).to receive(:search).with({author_guid: subject.guid}).and_return([])
         expect(subject.flagged_posts).to be_empty
       end
     end
@@ -144,7 +144,7 @@ describe ActiveRemote::Association do
       it { is_expected.to respond_to(:bestseller_posts) }
 
       it "searches the associated model for multiple record" do
-        expect(Post).to receive(:search).with({:bestseller_guid => subject.guid}).and_return(records)
+        expect(Post).to receive(:search).with({bestseller_guid: subject.guid}).and_return(records)
         expect(subject.bestseller_posts).to eq(records)
       end
     end
@@ -153,7 +153,7 @@ describe ActiveRemote::Association do
       it { is_expected.to respond_to(:user_posts) }
 
       it "searches the associated model for multiple records" do
-        expect(Post).to receive(:search).with({:author_guid => subject.guid, :user_guid => subject.user_guid}).and_return(records)
+        expect(Post).to receive(:search).with({author_guid: subject.guid, user_guid: subject.user_guid}).and_return(records)
         expect(subject.user_posts).to eq(records)
       end
 
@@ -180,8 +180,8 @@ describe ActiveRemote::Association do
     let(:user_guid) { "USR-123" }
     let(:category_attributes) {
       {
-        :guid => guid,
-        :user_guid => user_guid
+        guid: guid,
+        user_guid: user_guid
       }
     }
 
@@ -191,12 +191,12 @@ describe ActiveRemote::Association do
     it { is_expected.to respond_to(:author=) }
 
     it "searches the associated model for all associated records" do
-      expect(Author).to receive(:search).with({:category_guid => subject.guid}).and_return(records)
+      expect(Author).to receive(:search).with({category_guid: subject.guid}).and_return(records)
       expect(subject.author).to eq record
     end
 
     it "memoizes the result record" do
-      expect(Author).to receive(:search).once.with({:category_guid => subject.guid}).and_return(records)
+      expect(Author).to receive(:search).once.with({category_guid: subject.guid}).and_return(records)
       3.times { expect(subject.author).to eq record }
     end
 
@@ -210,7 +210,7 @@ describe ActiveRemote::Association do
 
     context "when the search is empty" do
       it "returns a nil value" do
-        expect(Author).to receive(:search).with({:category_guid => subject.guid}).and_return([])
+        expect(Author).to receive(:search).with({category_guid: subject.guid}).and_return([])
         expect(subject.author).to be_nil
       end
     end
@@ -219,7 +219,7 @@ describe ActiveRemote::Association do
       it { is_expected.to respond_to(:senior_author) }
 
       it "searches the associated model for a single record" do
-        expect(Author).to receive(:search).with({:category_guid => subject.guid}).and_return(records)
+        expect(Author).to receive(:search).with({category_guid: subject.guid}).and_return(records)
         expect(subject.senior_author).to eq record
       end
 
@@ -232,7 +232,7 @@ describe ActiveRemote::Association do
       it { is_expected.to respond_to(:primary_editor) }
 
       it "searches the associated model for a single record" do
-        expect(Author).to receive(:search).with({:editor_guid => subject.guid}).and_return(records)
+        expect(Author).to receive(:search).with({editor_guid: subject.guid}).and_return(records)
         expect(subject.primary_editor).to eq record
       end
     end
@@ -241,7 +241,7 @@ describe ActiveRemote::Association do
       it { is_expected.to respond_to(:chief_editor) }
 
       it "searches the associated model for multiple records" do
-        expect(Author).to receive(:search).with({:chief_editor_guid => subject.guid, :user_guid => subject.user_guid}).and_return(records)
+        expect(Author).to receive(:search).with({chief_editor_guid: subject.guid, user_guid: subject.user_guid}).and_return(records)
         expect(subject.chief_editor).to eq(record)
       end
 

--- a/spec/lib/active_remote/dirty_spec.rb
+++ b/spec/lib/active_remote/dirty_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe ActiveRemote::Dirty do
   context "when writing attributes through the setter" do
-    subject { Post.new(:name => "foo") }
+    subject { Post.new(name: "foo") }
 
     before do
       subject.changes_applied
@@ -23,7 +23,7 @@ describe ActiveRemote::Dirty do
   end
 
   context "when writing attributes directly" do
-    subject { Post.new(:name => "foo") }
+    subject { Post.new(name: "foo") }
 
     before do
       subject.changes_applied
@@ -44,10 +44,10 @@ describe ActiveRemote::Dirty do
   end
 
   describe "#reload" do
-    subject { Post.new(:name => "foo") }
+    subject { Post.new(name: "foo") }
 
     before do
-      allow(Post).to receive(:find).and_return(Post.new(:name => "foo"))
+      allow(Post).to receive(:find).and_return(Post.new(name: "foo"))
       subject.reload
     end
 
@@ -55,10 +55,10 @@ describe ActiveRemote::Dirty do
   end
 
   describe "#remote" do
-    let(:post) { Post.new(:name => "foo") }
+    let(:post) { Post.new(name: "foo") }
 
     it "clears changes information" do
-      allow(post).to receive(:remote_call).and_return(::Generic::Remote::Post.new(:name => "foo"))
+      allow(post).to receive(:remote_call).and_return(::Generic::Remote::Post.new(name: "foo"))
       expect { post.remote(:reload) }.to change { post.changed? }.to(false)
     end
   end
@@ -66,7 +66,7 @@ describe ActiveRemote::Dirty do
   describe "#save" do
     let!(:changes) { subject.changes }
 
-    subject { Post.new(:name => "foo") }
+    subject { Post.new(name: "foo") }
 
     before do
       allow(subject).to receive(:create_or_update).and_return(true)
@@ -80,7 +80,7 @@ describe ActiveRemote::Dirty do
   describe "#save!" do
     let!(:changes) { subject.changes }
 
-    subject { Post.new(:name => "foo") }
+    subject { Post.new(name: "foo") }
 
     before do
       allow(subject).to receive(:save).and_return(true)

--- a/spec/lib/active_remote/dsl_spec.rb
+++ b/spec/lib/active_remote/dsl_spec.rb
@@ -24,19 +24,19 @@ describe ActiveRemote::DSL do
   describe ".endpoints" do
     it "has default values" do
       expect(Tag.endpoints).to eq(
-        :create => :create,
-        :delete => :delete,
-        :destroy => :destroy,
-        :search => :search,
-        :update => :update
+        create: :create,
+        delete: :delete,
+        destroy: :destroy,
+        search: :search,
+        update: :update
       )
     end
 
     context "given a new value for an endpoint" do
-      after { Tag.endpoints(:create => :create) }
+      after { Tag.endpoints(create: :create) }
 
       it "overwrites default values" do
-        Tag.endpoints(:create => :register)
+        Tag.endpoints(create: :register)
         expect(Tag.endpoints[:create]).to eq(:register)
       end
     end

--- a/spec/lib/active_remote/errors_spec.rb
+++ b/spec/lib/active_remote/errors_spec.rb
@@ -4,8 +4,8 @@ describe ::ActiveRemote::RemoteRecordNotSaved do
   let(:record) { ::Tag.new }
 
   before do
-    record.errors.add(:base, :invalid, :message => "Some error one!")
-    record.errors.add(:base, :invalid, :message => "Some error two!")
+    record.errors.add(:base, :invalid, message: "Some error one!")
+    record.errors.add(:base, :invalid, message: "Some error two!")
   end
 
   context "when an active remote record is used" do

--- a/spec/lib/active_remote/integration_spec.rb
+++ b/spec/lib/active_remote/integration_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe ::ActiveRemote::Integration do
   let(:guid) { "GUID-derp" }
-  let(:tag) { ::Tag.new(:guid => guid) }
+  let(:tag) { ::Tag.new(guid: guid) }
 
   subject { tag }
 
@@ -46,7 +46,7 @@ describe ::ActiveRemote::Integration do
   end
 
   describe "#cache_key_with_version" do
-    let(:tag) { ::Tag.new(:guid => guid, :updated_at => ::DateTime.current) }
+    let(:tag) { ::Tag.new(guid: guid, updated_at: ::DateTime.current) }
 
     specify { expect(subject).to respond_to(:cache_key_with_version) }
 

--- a/spec/lib/active_remote/persistence_spec.rb
+++ b/spec/lib/active_remote/persistence_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe ::ActiveRemote::Persistence do
-  let(:response_without_errors) { ::HashWithIndifferentAccess.new(:errors => []) }
+  let(:response_without_errors) { ::HashWithIndifferentAccess.new(errors: []) }
   let(:rpc) { ::ActiveRemote::RPCAdapters::ProtobufAdapter.new(::Tag.service_class, ::Tag.endpoints) }
 
   subject { ::Tag.new }
@@ -15,16 +15,16 @@ describe ::ActiveRemote::Persistence do
   describe ".create" do
     it "runs create callbacks" do
       expect_any_instance_of(Tag).to receive(:after_create_callback)
-      Tag.create(:name => "foo")
+      Tag.create(name: "foo")
     end
 
     it "initializes and saves a new record" do
       expect_any_instance_of(Tag).to receive(:save)
-      Tag.create(:name => "foo")
+      Tag.create(name: "foo")
     end
 
     it "returns a new record" do
-      value = Tag.create(:name => "foo")
+      value = Tag.create(name: "foo")
       expect(value).to be_a(Tag)
     end
   end
@@ -32,14 +32,14 @@ describe ::ActiveRemote::Persistence do
   describe ".create!" do
     it "initializes and saves a new record" do
       expect_any_instance_of(Tag).to receive(:save!)
-      Tag.create!(:name => "foo")
+      Tag.create!(name: "foo")
     end
 
     context "when the record has errors" do
       before { allow_any_instance_of(Tag).to receive(:save!).and_raise(ActiveRemote::ActiveRemoteError) }
 
       it "raises an exception" do
-        expect { Tag.create!(:name => "foo") }.to raise_error(ActiveRemote::ActiveRemoteError)
+        expect { Tag.create!(name: "foo") }.to raise_error(ActiveRemote::ActiveRemoteError)
       end
     end
   end
@@ -58,8 +58,8 @@ describe ::ActiveRemote::Persistence do
     end
 
     context "when the response has errors" do
-      let(:error) { Generic::Error.new(:field => "name", :message => "Boom!") }
-      let(:response) { Generic::Remote::Tag.new(:errors => [error]) }
+      let(:error) { Generic::Error.new(field: "name", message: "Boom!") }
+      let(:response) { Generic::Remote::Tag.new(errors: [error]) }
 
       before { allow(rpc).to receive(:execute).and_return(response) }
 
@@ -81,8 +81,8 @@ describe ::ActiveRemote::Persistence do
     end
 
     context "when an error occurs" do
-      let(:error) { Generic::Error.new(:field => "name", :message => "Boom!") }
-      let(:response) { Generic::Remote::Tag.new(:errors => [error]) }
+      let(:error) { Generic::Error.new(field: "name", message: "Boom!") }
+      let(:response) { Generic::Remote::Tag.new(errors: [error]) }
 
       before { allow(rpc).to receive(:execute).and_return(response) }
 
@@ -106,8 +106,8 @@ describe ::ActiveRemote::Persistence do
     end
 
     context "when the response has errors" do
-      let(:error) { Generic::Error.new(:field => "name", :message => "Boom!") }
-      let(:response) { Generic::Remote::Tag.new(:errors => [error]) }
+      let(:error) { Generic::Error.new(field: "name", message: "Boom!") }
+      let(:response) { Generic::Remote::Tag.new(errors: [error]) }
 
       before { allow(rpc).to receive(:execute).and_return(response) }
 
@@ -129,8 +129,8 @@ describe ::ActiveRemote::Persistence do
     end
 
     context "when an error occurs" do
-      let(:error) { Generic::Error.new(:field => "name", :message => "Boom!") }
-      let(:response) { Generic::Remote::Tag.new(:errors => [error]) }
+      let(:error) { Generic::Error.new(field: "name", message: "Boom!") }
+      let(:response) { Generic::Remote::Tag.new(errors: [error]) }
 
       before { allow(rpc).to receive(:execute).and_return(response) }
 
@@ -148,7 +148,7 @@ describe ::ActiveRemote::Persistence do
     end
 
     context "when errors are present" do
-      before { subject.errors.add(:base, :invalid, :message => "Boom!") }
+      before { subject.errors.add(:base, :invalid, message: "Boom!") }
 
       its(:has_errors?) { should be_truthy }
     end
@@ -156,13 +156,13 @@ describe ::ActiveRemote::Persistence do
 
   describe "#new_record?" do
     context "when the record is created through instantiate" do
-      subject { Tag.instantiate(:guid => "foo") }
+      subject { Tag.instantiate(guid: "foo") }
 
       its(:new_record?) { should be_falsey }
     end
 
     context "when the record is persisted" do
-      subject { Tag.allocate.instantiate(:guid => "foo") }
+      subject { Tag.allocate.instantiate(guid: "foo") }
 
       its(:new_record?) { should be_falsey }
     end
@@ -176,7 +176,7 @@ describe ::ActiveRemote::Persistence do
 
   describe "#persisted?" do
     context "when the record is persisted" do
-      subject { Tag.allocate.instantiate(:guid => "foo") }
+      subject { Tag.allocate.instantiate(guid: "foo") }
 
       its(:persisted?) { should be_truthy }
     end
@@ -190,7 +190,7 @@ describe ::ActiveRemote::Persistence do
 
   describe "#readonly?" do
     context "when the record is created through instantiate with options[:readonly]" do
-      subject { Tag.instantiate({ :guid => "foo" }, :readonly => true) }
+      subject { Tag.instantiate({guid: "foo"}, readonly: true) }
 
       its(:new_record?) { should be_falsey }
       its(:readonly?) { should be_truthy }
@@ -198,9 +198,9 @@ describe ::ActiveRemote::Persistence do
   end
 
   describe "#remote" do
-    let(:response) { ::Generic::Remote::Tag.new(:guid => tag.guid, :name => "bar") }
+    let(:response) { ::Generic::Remote::Tag.new(guid: tag.guid, name: "bar") }
     let(:rpc) { ::ActiveRemote::RPCAdapters::ProtobufAdapter.new(::Tag.service_class, ::Tag.endpoints) }
-    let(:tag) { ::Tag.new(:guid => SecureRandom.uuid) }
+    let(:tag) { ::Tag.new(guid: SecureRandom.uuid) }
 
     subject { tag }
 
@@ -224,7 +224,7 @@ describe ::ActiveRemote::Persistence do
 
     context "when request args are given" do
       it "calls the given RPC method with default args" do
-        attributes = { :guid => tag.guid, :name => "foo" }
+        attributes = {guid: tag.guid, name: "foo"}
         expect(::Tag.rpc).to receive(:execute).with(:remote_method, attributes)
         tag.remote(:remote_method, attributes)
       end
@@ -232,14 +232,14 @@ describe ::ActiveRemote::Persistence do
 
     context "when response does not respond to errors" do
       it "returns true" do
-        allow(rpc).to receive(:execute).and_return(double(:response, :to_hash => ::Hash.new))
+        allow(rpc).to receive(:execute).and_return(double(:response, to_hash: {}))
         expect(tag.remote(:remote_method)).to be(true)
       end
     end
 
     context "when errors are returned" do
       let(:response) {
-        ::Generic::Remote::Tag.new(:guid => tag.guid, :name => "bar", :errors => [{ :field => "name", :message => "message" }])
+        ::Generic::Remote::Tag.new(guid: tag.guid, name: "bar", errors: [{field: "name", message: "message"}])
       }
 
       it "adds errors from the response" do
@@ -270,7 +270,7 @@ describe ::ActiveRemote::Persistence do
     end
 
     context "when the record is not new" do
-      let(:attributes) { { "guid" => "foo" } }
+      let(:attributes) { {"guid" => "foo"} }
 
       subject { Tag.allocate.instantiate(attributes) }
 
@@ -295,7 +295,7 @@ describe ::ActiveRemote::Persistence do
     end
 
     context "when the record has errors before the save" do
-      before { subject.errors.add(:base, :invalid, :message => "Boom!") }
+      before { subject.errors.add(:base, :invalid, message: "Boom!") }
 
       it "clears the errors before the save" do
         expect(subject.errors).not_to be_empty
@@ -315,10 +315,10 @@ describe ::ActiveRemote::Persistence do
 
     context "when the record is not saved" do
       let(:errors) {
-        [Generic::Error.new(:field => "name", :message => "Error one!"),
-         Generic::Error.new(:field => "name", :message => "Error two!")]
+        [Generic::Error.new(field: "name", message: "Error one!"),
+          Generic::Error.new(field: "name", message: "Error two!")]
       }
-      let(:response) { Generic::Remote::Tag.new(:errors => errors) }
+      let(:response) { Generic::Remote::Tag.new(errors: errors) }
       before { allow(rpc).to receive(:execute).and_return(response) }
 
       it "raises an exception" do
@@ -330,7 +330,7 @@ describe ::ActiveRemote::Persistence do
 
   describe "#success?" do
     context "when errors are present" do
-      before { subject.errors.add(:base, :invalid, :message => "Boom!") }
+      before { subject.errors.add(:base, :invalid, message: "Boom!") }
 
       its(:success?) { should be_falsey }
     end
@@ -343,7 +343,7 @@ describe ::ActiveRemote::Persistence do
   end
 
   describe "#update_attribute" do
-    let(:tag) { Tag.allocate.instantiate(:guid => "123") }
+    let(:tag) { Tag.allocate.instantiate(guid: "123") }
 
     it "runs update callbacks" do
       expect(tag).to receive(:after_update_callback)
@@ -370,8 +370,8 @@ describe ::ActiveRemote::Persistence do
   end
 
   describe "#update_attributes" do
-    let(:attributes) { HashWithIndifferentAccess.new(:name => "bar") }
-    let(:tag) { Tag.allocate.instantiate(:guid => "123") }
+    let(:attributes) { HashWithIndifferentAccess.new(name: "bar") }
+    let(:tag) { Tag.allocate.instantiate(guid: "123") }
 
     it "runs update callbacks" do
       expect(tag).to receive(:after_update_callback)
@@ -398,7 +398,7 @@ describe ::ActiveRemote::Persistence do
   end
 
   describe "#update_attributes!" do
-    let(:attributes) { HashWithIndifferentAccess.new(:name => "bar") }
+    let(:attributes) { HashWithIndifferentAccess.new(name: "bar") }
 
     before { allow(subject).to receive(:save!) }
     after { allow(subject).to receive(:save!).and_call_original }

--- a/spec/lib/active_remote/primary_key_spec.rb
+++ b/spec/lib/active_remote/primary_key_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe ActiveRemote::PrimaryKey do
-  let(:tag) { Tag.new(:id => "1234", :guid => "TAG-123", :user_guid => "USR-123") }
+  let(:tag) { Tag.new(id: "1234", guid: "TAG-123", user_guid: "USR-123") }
 
   after { Tag.instance_variable_set :@primary_key, nil }
 
@@ -42,7 +42,7 @@ describe ActiveRemote::PrimaryKey do
 
     context "when no primary key is specified, but default of guid exists" do
       it "returns guid in array" do
-        expect(Tag.new(:guid => "TAG-123").to_key).to eq ["TAG-123"]
+        expect(Tag.new(guid: "TAG-123").to_key).to eq ["TAG-123"]
       end
     end
   end

--- a/spec/lib/active_remote/rpc_adapters/protobuf_adapter_spec.rb
+++ b/spec/lib/active_remote/rpc_adapters/protobuf_adapter_spec.rb
@@ -17,7 +17,7 @@ describe ActiveRemote::RPCAdapters::ProtobufAdapter do
 
       it "calls the custom endpoint" do
         expect(adapter.client).to receive(:register)
-        adapter.execute(:create, :name => "foo")
+        adapter.execute(:create, name: "foo")
       end
     end
   end

--- a/spec/lib/active_remote/rpc_spec.rb
+++ b/spec/lib/active_remote/rpc_spec.rb
@@ -4,7 +4,7 @@ describe ::ActiveRemote::RPC do
   subject { ::Tag.new }
 
   describe ".build_from_rpc" do
-    let(:new_attributes) { { :name => "test" } }
+    let(:new_attributes) { {name: "test"} }
 
     it "dups the default attributes" do
       expect { ::Tag.build_from_rpc(new_attributes) }.to_not change { ::Tag._default_attributes["name"] }
@@ -17,7 +17,7 @@ describe ::ActiveRemote::RPC do
     end
 
     context "extra attributes from rpc" do
-      let(:new_attributes) { { :foobar => "test" } }
+      let(:new_attributes) { {foobar: "test"} }
 
       it "ignores unknown attributes" do
         expect(::Tag.build_from_rpc(new_attributes)).to_not include("foobar" => "test")
@@ -25,7 +25,7 @@ describe ::ActiveRemote::RPC do
     end
 
     context "typecasted attributes" do
-      let(:new_attributes) { { :birthday => "2017-01-01" } }
+      let(:new_attributes) { {birthday: "2017-01-01"} }
 
       it "calls the typecasters" do
         expect(
@@ -56,15 +56,15 @@ describe ::ActiveRemote::RPC do
   end
 
   describe "#assign_attributes_from_rpc" do
-    let(:response) { ::Generic::Remote::Tag.new(:guid => tag.guid, :name => "bar") }
-    let(:tag) { ::Tag.new(:guid => SecureRandom.uuid) }
+    let(:response) { ::Generic::Remote::Tag.new(guid: tag.guid, name: "bar") }
+    let(:tag) { ::Tag.new(guid: SecureRandom.uuid) }
 
     it "updates the attributes from the response" do
       expect { tag.assign_attributes_from_rpc(response) }.to change { tag.name }.to(response.name)
     end
 
     context "when response does not respond to errors" do
-      let(:response) { double(:response, :to_hash => ::Hash.new) }
+      let(:response) { double(:response, to_hash: {}) }
 
       it "does not add errors from the response" do
         expect { tag.assign_attributes_from_rpc(response) }.to_not change { tag.has_errors? }
@@ -74,9 +74,9 @@ describe ::ActiveRemote::RPC do
     context "when errors are returned" do
       let(:response) {
         ::Generic::Remote::Tag.new(
-          :guid => tag.guid,
-          :name => "bar",
-          :errors => [{ :field => "name", :message => "message" }]
+          guid: tag.guid,
+          name: "bar",
+          errors: [{field: "name", message: "message"}]
         )
       }
 

--- a/spec/lib/active_remote/scope_keys_spec.rb
+++ b/spec/lib/active_remote/scope_keys_spec.rb
@@ -5,7 +5,7 @@ describe ActiveRemote::ScopeKeys do
   let(:_scope_keys) { ["user_guid"] }
   let(:scope_keys) { ["guid"] + _scope_keys }
   let(:tag) { Tag.new(tag_hash) }
-  let(:tag_hash) { { :guid => "TAG-123", :user_guid => "USR-123", :name => "teh tag" } }
+  let(:tag_hash) { {guid: "TAG-123", user_guid: "USR-123", name: "teh tag"} }
 
   describe ".scope_key" do
     after { Tag._scope_keys = [] }
@@ -31,7 +31,7 @@ describe ActiveRemote::ScopeKeys do
   end
 
   describe "#scope_key_hash" do
-    let(:scope_key_hash) { { "guid" => "TAG-123", "user_guid" => "USR-123" } }
+    let(:scope_key_hash) { {"guid" => "TAG-123", "user_guid" => "USR-123"} }
 
     before { allow(tag).to receive(:scope_keys).and_return(scope_keys) }
 

--- a/spec/lib/active_remote/search_spec.rb
+++ b/spec/lib/active_remote/search_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
 describe ActiveRemote::Search do
-  let(:records) { [Generic::Remote::Tag.new(:guid => "123")] }
-  let(:response) { Generic::Remote::Tags.new(:records => records) }
+  let(:records) { [Generic::Remote::Tag.new(guid: "123")] }
+  let(:response) { Generic::Remote::Tags.new(records: records) }
   let(:rpc) { double(:rpc) }
 
   describe ".find" do
@@ -64,7 +64,7 @@ describe ActiveRemote::Search do
   end
 
   describe ".search" do
-    let(:serialized_records) { [Tag.instantiate(:guid => "123")] }
+    let(:serialized_records) { [Tag.instantiate(guid: "123")] }
 
     context "given args that respond to :to_hash" do
       let(:args) { {} }
@@ -95,7 +95,7 @@ describe ActiveRemote::Search do
 
   describe "#reload" do
     let(:args) { attributes.slice("guid", "user_guid") }
-    let(:attributes) { HashWithIndifferentAccess.new(:guid => "foo", :name => "bar", :updated_at => nil, :user_guid => "baz") }
+    let(:attributes) { HashWithIndifferentAccess.new(guid: "foo", name: "bar", updated_at: nil, user_guid: "baz") }
 
     subject { Tag.new(args) }
 

--- a/spec/lib/active_remote/serialization_spec.rb
+++ b/spec/lib/active_remote/serialization_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe ActiveRemote::Serialization do
   describe ".serialize_records" do
-    let(:records) { [{ :foo => "bar" }] }
+    let(:records) { [{foo: "bar"}] }
 
     subject { Tag.new }
 
@@ -14,7 +14,7 @@ describe ActiveRemote::Serialization do
   end
 
   describe "#add_errors" do
-    let(:error) { Generic::Error.new(:field => "name", :message => "Boom!") }
+    let(:error) { Generic::Error.new(field: "name", message: "Boom!") }
     let(:response) {
       tag = Generic::Remote::Tag.new
       tag.errors << error

--- a/spec/lib/active_remote/serializers/protobuf_spec.rb
+++ b/spec/lib/active_remote/serializers/protobuf_spec.rb
@@ -2,8 +2,8 @@ require "spec_helper"
 
 describe ActiveRemote::Serializers::Protobuf::Fields do
   describe ".from_attributes" do
-    let(:ready_value) { { :records => [{ :name => "Cool Post", :errors => [{ :message => "Boom!" }] }] } }
-    let(:value) { { :records => { :name => "Cool Post", :errors => { :message => "Boom!" } } } }
+    let(:ready_value) { {records: [{name: "Cool Post", errors: [{message: "Boom!"}]}]} }
+    let(:value) { {records: {name: "Cool Post", errors: {message: "Boom!"}}} }
 
     it "gets protobuf-ready fields from attributes" do
       expect(described_class.from_attributes(Generic::Remote::Posts, value)).to eq ready_value
@@ -17,8 +17,8 @@ describe ActiveRemote::Serializers::Protobuf::Field do
       let(:field) { Generic::Remote::Posts.get_field(:records) }
 
       context "and the value is not an array" do
-        let(:ready_value) { [{ :name => "Cool Post", :errors => [{ :message => "Boom!" }] }] }
-        let(:value) { { :name => "Cool Post", :errors => { :message => "Boom!" } } }
+        let(:ready_value) { [{name: "Cool Post", errors: [{message: "Boom!"}]}] }
+        let(:value) { {name: "Cool Post", errors: {message: "Boom!"}} }
 
         it "gets protobuf-ready fields from the value" do
           expect(described_class.from_attribute(field, value)).to eq ready_value
@@ -30,8 +30,8 @@ describe ActiveRemote::Serializers::Protobuf::Field do
       let(:field) { Generic::Remote::Post.get_field(:category) }
 
       context "and value is a hash" do
-        let(:ready_value) { { :name => "Film", :errors => [{ :message => "Boom!" }] } }
-        let(:value) { { :name => "Film", :errors => { :message => "Boom!" } } }
+        let(:ready_value) { {name: "Film", errors: [{message: "Boom!"}]} }
+        let(:value) { {name: "Film", errors: {message: "Boom!"}} }
 
         it "gets protobuf-ready fields from the value" do
           expect(described_class.from_attribute(field, value)).to eq ready_value
@@ -61,7 +61,7 @@ describe ActiveRemote::Serializers::Protobuf::Field do
     # typecasting.
     #
     context "when typecasting fields" do
-      let(:string_value) { double(:string, :to_s => "") }
+      let(:string_value) { double(:string, to_s: "") }
 
       def typecasts(field, conversion)
         field = Serializer.get_field(field, true)

--- a/spec/lib/active_remote/validations_spec.rb
+++ b/spec/lib/active_remote/validations_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe ActiveRemote::Validations do
   let(:invalid_record) { ::Post.new }
-  let(:valid_record) { ::Post.new(:name => "test") }
+  let(:valid_record) { ::Post.new(name: "test") }
 
   before { allow(valid_record).to receive(:create_or_update).and_return(true) }
   before { allow(invalid_record).to receive(:create_or_update).and_return(true) }

--- a/spec/support/models/author.rb
+++ b/spec/support/models/author.rb
@@ -18,9 +18,9 @@ class Author < ::ActiveRemote::Base
   attribute :net_sales, :float
 
   has_many :posts
-  has_many :user_posts, :class_name => "::Post", :scope => :user_guid
-  has_many :flagged_posts, :class_name => "::Post"
-  has_many :bestseller_posts, :class_name => "::Post", :foreign_key => :bestseller_guid
+  has_many :user_posts, class_name: "::Post", scope: :user_guid
+  has_many :flagged_posts, class_name: "::Post"
+  has_many :bestseller_posts, class_name: "::Post", foreign_key: :bestseller_guid
 
   belongs_to :category
 end

--- a/spec/support/models/category.rb
+++ b/spec/support/models/category.rb
@@ -13,7 +13,7 @@ class Category < ::ActiveRemote::Base
   has_many :posts
 
   has_one :author
-  has_one :senior_author, :class_name => "::Author"
-  has_one :primary_editor, :class_name => "::Author", :foreign_key => :editor_guid
-  has_one :chief_editor, :class_name => "::Author", :scope => :user_guid, :foreign_key => :chief_editor_guid
+  has_one :senior_author, class_name: "::Author"
+  has_one :primary_editor, class_name: "::Author", foreign_key: :editor_guid
+  has_one :chief_editor, class_name: "::Author", scope: :user_guid, foreign_key: :chief_editor_guid
 end

--- a/spec/support/models/default_author.rb
+++ b/spec/support/models/default_author.rb
@@ -6,7 +6,7 @@ require "support/protobuf/author.pb"
 class DefaultAuthor < ::ActiveRemote::Base
   service_class ::Generic::Remote::AuthorService
 
-  attribute :guid, :string, :default => lambda { 100 }
-  attribute :name, :string, :default => "John Doe"
-  attribute :books, :default => []
+  attribute :guid, :string, default: lambda { 100 }
+  attribute :name, :string, default: "John Doe"
+  attribute :books, default: []
 end

--- a/spec/support/models/post.rb
+++ b/spec/support/models/post.rb
@@ -13,9 +13,9 @@ class Post < ::ActiveRemote::Base
   attribute :bestseller_guid, :string
 
   belongs_to :author
-  belongs_to :coauthor, :class_name => "::Author"
-  belongs_to :bestseller, :class_name => "::Author", :foreign_key => :bestseller_guid
-  belongs_to :user, :class_name => "::Author", :scope => :user_guid
+  belongs_to :coauthor, class_name: "::Author"
+  belongs_to :bestseller, class_name: "::Author", foreign_key: :bestseller_guid
+  belongs_to :user, class_name: "::Author", scope: :user_guid
 
-  validates :name, :presence => true
+  validates :name, presence: true
 end

--- a/spec/support/protobuf/author.pb.rb
+++ b/spec/support/protobuf/author.pb.rb
@@ -1,16 +1,13 @@
-# encoding: utf-8
-
 ##
 # This file is auto-generated. DO NOT EDIT!
 #
-require 'protobuf'
-require 'protobuf/rpc/service'
-
+require "protobuf"
+require "protobuf/rpc/service"
 
 ##
 # Imports
 #
-require 'error.pb'
+require "error.pb"
 
 module Generic
   module Remote
@@ -20,9 +17,10 @@ module Generic
     # Message Classes
     #
     class Author < ::Protobuf::Message; end
-    class Authors < ::Protobuf::Message; end
-    class AuthorRequest < ::Protobuf::Message; end
 
+    class Authors < ::Protobuf::Message; end
+
+    class AuthorRequest < ::Protobuf::Message; end
 
     ##
     # Message Fields
@@ -43,7 +41,6 @@ module Generic
       repeated :string, :name, 2
     end
 
-
     ##
     # Service Classes
     #
@@ -57,8 +54,5 @@ module Generic
       rpc :delete_all, ::Generic::Remote::Authors, ::Generic::Remote::Authors
       rpc :destroy_all, ::Generic::Remote::Authors, ::Generic::Remote::Authors
     end
-
   end
-
 end
-

--- a/spec/support/protobuf/category.pb.rb
+++ b/spec/support/protobuf/category.pb.rb
@@ -1,16 +1,13 @@
-# encoding: utf-8
-
 ##
 # This file is auto-generated. DO NOT EDIT!
 #
-require 'protobuf'
-require 'protobuf/rpc/service'
-
+require "protobuf"
+require "protobuf/rpc/service"
 
 ##
 # Imports
 #
-require 'error.pb'
+require "error.pb"
 
 module Generic
   module Remote
@@ -20,9 +17,10 @@ module Generic
     # Message Classes
     #
     class Category < ::Protobuf::Message; end
-    class Categories < ::Protobuf::Message; end
-    class CategoryRequest < ::Protobuf::Message; end
 
+    class Categories < ::Protobuf::Message; end
+
+    class CategoryRequest < ::Protobuf::Message; end
 
     ##
     # Message Fields
@@ -46,7 +44,6 @@ module Generic
       repeated :string, :name, 2
     end
 
-
     ##
     # Service Classes
     #
@@ -60,8 +57,5 @@ module Generic
       rpc :delete_all, ::Generic::Remote::Categories, ::Generic::Remote::Categories
       rpc :destroy_all, ::Generic::Remote::Categories, ::Generic::Remote::Categories
     end
-
   end
-
 end
-

--- a/spec/support/protobuf/error.pb.rb
+++ b/spec/support/protobuf/error.pb.rb
@@ -1,9 +1,7 @@
-# encoding: utf-8
-
 ##
 # This file is auto-generated. DO NOT EDIT!
 #
-require 'protobuf'
+require "protobuf"
 
 module Generic
   ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
@@ -13,7 +11,6 @@ module Generic
   #
   class Error < ::Protobuf::Message; end
 
-
   ##
   # Message Fields
   #
@@ -21,6 +18,4 @@ module Generic
     optional :string, :field, 1
     optional :string, :message, 2
   end
-
 end
-

--- a/spec/support/protobuf/post.pb.rb
+++ b/spec/support/protobuf/post.pb.rb
@@ -1,17 +1,14 @@
-# encoding: utf-8
-
 ##
 # This file is auto-generated. DO NOT EDIT!
 #
-require 'protobuf'
-require 'protobuf/rpc/service'
-
+require "protobuf"
+require "protobuf/rpc/service"
 
 ##
 # Imports
 #
-require 'error.pb'
-require 'category.pb'
+require "error.pb"
+require "category.pb"
 
 module Generic
   module Remote
@@ -21,9 +18,10 @@ module Generic
     # Message Classes
     #
     class Post < ::Protobuf::Message; end
-    class Posts < ::Protobuf::Message; end
-    class PostRequest < ::Protobuf::Message; end
 
+    class Posts < ::Protobuf::Message; end
+
+    class PostRequest < ::Protobuf::Message; end
 
     ##
     # Message Fields
@@ -48,7 +46,6 @@ module Generic
       repeated :string, :user_guid, 4
     end
 
-
     ##
     # Service Classes
     #
@@ -62,8 +59,5 @@ module Generic
       rpc :delete_all, ::Generic::Remote::Posts, ::Generic::Remote::Posts
       rpc :destroy_all, ::Generic::Remote::Posts, ::Generic::Remote::Posts
     end
-
   end
-
 end
-

--- a/spec/support/protobuf/serializer.pb.rb
+++ b/spec/support/protobuf/serializer.pb.rb
@@ -1,10 +1,7 @@
-# encoding: utf-8
-
 ##
 # This file is auto-generated. DO NOT EDIT!
 #
-require 'protobuf'
-
+require "protobuf"
 
 ##
 # Message Classes
@@ -14,10 +11,7 @@ class Serializer < ::Protobuf::Message
     define :DEFAULT, 0
     define :USER, 1
   end
-
 end
-
-
 
 ##
 # Message Fields
@@ -40,4 +34,3 @@ class Serializer
   optional :uint64, :uint64_field, 15
   optional ::Serializer::Type, :enum_field, 16
 end
-

--- a/spec/support/protobuf/tag.pb.rb
+++ b/spec/support/protobuf/tag.pb.rb
@@ -1,16 +1,13 @@
-# encoding: utf-8
-
 ##
 # This file is auto-generated. DO NOT EDIT!
 #
-require 'protobuf'
-require 'protobuf/rpc/service'
-
+require "protobuf"
+require "protobuf/rpc/service"
 
 ##
 # Imports
 #
-require 'error.pb'
+require "error.pb"
 
 module Generic
   module Remote
@@ -20,9 +17,10 @@ module Generic
     # Message Classes
     #
     class Tag < ::Protobuf::Message; end
-    class Tags < ::Protobuf::Message; end
-    class TagRequest < ::Protobuf::Message; end
 
+    class Tags < ::Protobuf::Message; end
+
+    class TagRequest < ::Protobuf::Message; end
 
     ##
     # Message Fields
@@ -42,7 +40,6 @@ module Generic
       repeated :string, :name, 2
     end
 
-
     ##
     # Service Classes
     #
@@ -57,8 +54,5 @@ module Generic
       rpc :delete_all, ::Generic::Remote::Tags, ::Generic::Remote::Tags
       rpc :destroy_all, ::Generic::Remote::Tags, ::Generic::Remote::Tags
     end
-
   end
-
 end
-


### PR DESCRIPTION
Replace Mad Rubocop with Standard to follow Ruby community styles. Fix rule violations, and add a lint job to the CI workflow that checks for violations on all pull requests.