### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,9 +11,9 @@ name: Ruby CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   test:
@@ -21,7 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, head, debug, jruby-9.3, jruby-9.4, jruby-head, truffleruby, truffleruby-head]
+        ruby:
+          [2.7, 3.0, 3.1, head, debug, jruby-9.4, jruby-head, truffleruby-head]
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
       - uses: actions/checkout@v4
@@ -29,4 +30,4 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
       - run: bundle install
-      - run: bundle rspec
+      - run: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
----
-language: ruby
-rvm:
-  - 2.5
-  - jruby


### PR DESCRIPTION
CI is running with GitHub Actions, so TravisCI config is no longer needed. Remove it.

Also add testing support for 3.0 and 3.1, and remove testing support for 2.5 and 2.6 (JRuby 9.3) since Rails 7.0 requires 2.7.