### PR TITLE
Rails 7.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby:
-          [2.7, 3.0, 3.1, head, debug, jruby-9.4, jruby-head, truffleruby-head]
+        ruby: [3.1, 3.2, head, debug, jruby-head, truffleruby-head]
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
       - uses: actions/checkout@v4

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,2 +1,3 @@
-parallel: true # default: false
+# For available configuration options, see:
+#   https://github.com/standardrb/standard
 format: progress # default: Standard::Formatter

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update to ActiveModel 7.2
+- Require Ruby 3.1 (to match Rails)
+
 ## [7.1.0] - 2024-12-04
 
 ### Changed

--- a/active_remote.gemspec
+++ b/active_remote.gemspec
@@ -14,13 +14,13 @@ Gem::Specification.new do |s|
   s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = ">= 2.7.0"
+  s.required_ruby_version = ">= 3.1.0"
 
   ##
   # Dependencies
   #
-  s.add_dependency "activemodel", "~> 7.1.0"
-  s.add_dependency "activesupport", "~> 7.1.0"
+  s.add_dependency "activemodel", "~> 7.2.0"
+  s.add_dependency "activesupport", "~> 7.2.0"
   s.add_dependency "protobuf", ">= 3.0"
 
   ##


### PR DESCRIPTION
Rails 7.2 targets Ruby 3.1+. Update to Active Model 7.2, and update the minimum Ruby version accordingly. JRuby 9.4 targets Ruby 2.7 compatibility, so drop it from the CI workflow (keeping `jruby-head` since it targets Ruby 3.1+).