### PR TITLE
Match Rails dirty tracking behavior

### DIFF
--- a/lib/active_remote/base.rb
+++ b/lib/active_remote/base.rb
@@ -49,10 +49,8 @@ module ActiveRemote
       super
       @new_record = true
 
-      skip_dirty_tracking do
-        run_callbacks :initialize do
-          yield self if block_given?
-        end
+      run_callbacks :initialize do
+        yield self if block_given?
       end
     end
 

--- a/lib/active_remote/dirty.rb
+++ b/lib/active_remote/dirty.rb
@@ -8,16 +8,6 @@ module ActiveRemote
 
     included do
       include ActiveModel::Dirty
-
-      attr_accessor :_active_remote_track_changes
-    end
-
-    def disable_dirty_tracking
-      @_active_remote_track_changes = false
-    end
-
-    def enable_dirty_tracking
-      @_active_remote_track_changes = true
     end
 
     # Override #reload to provide dirty tracking.
@@ -54,29 +44,7 @@ module ActiveRemote
       end
     end
 
-    def skip_dirty_tracking
-      disable_dirty_tracking
-
-      yield
-
-      enable_dirty_tracking
-    end
-
     private
-
-    # Wether or not changes are currently being tracked for this class.
-    #
-    def _active_remote_track_changes?
-      @_active_remote_track_changes != false
-    end
-
-    # Override ActiveAttr's attribute= method so we can provide support for
-    # ActiveModel::Dirty.
-    #
-    def attribute=(name, value)
-      send(:"#{name}_will_change!") if _active_remote_track_changes? && value != self[name]
-      super
-    end
 
     # Override #update to only send changed attributes.
     #


### PR DESCRIPTION
Do not skip dirty tracking when initializing to match Rails behavior. Instead, use .instantiate, or manually reset changes as needed.