### PR TITLE
to_s(:db) has been deprecated and the alias to to_fs has been removed

### DIFF
--- a/lib/active_remote/attribute_methods.rb
+++ b/lib/active_remote/attribute_methods.rb
@@ -42,7 +42,7 @@ module ActiveRemote
       if value.is_a?(String) && value.length > 50
         "#{value[0, 50]}...".inspect
       elsif value.is_a?(Date) || value.is_a?(Time)
-        %("#{value.to_s(:db)}")
+        %("#{value.to_fs(:db)}")
       else
         value.inspect
       end


### PR DESCRIPTION
to_s(:db) has been deprecated and the alias to to_fs has been removed in Rails 7.1, creating an incompatibility.

Last week I found what I believe to be a Rails 7.1 incompatibility in ActiveRemote when running some search calls from a Rails console:
```
An error occurred when inspecting the object: #<ArgumentError: `to_s': wrong number of arguments (given 1, expected 0)>
An error occurred when running Kernel#inspect: #<ArgumentError: `to_s': wrong number of arguments (given 1, expected 0)>
/srv/amigo/vendor/bundle/jruby/3.1.0/gems/active_remote-7.1.0/lib/active_remote/attribute_methods.rb:45:in `attribute_for_inspect'
```
It looks like to_s(:db) for Date and Time objects had been deprecated for a while, but Rails had been aliasing to_s(arg) to the new, preferred to_fs or to_formatted_s methods right up until Rails 7.  In older versions of Rails active_support/core_ext/date_time/conversions.rb, we had an alias for :to_s -> :to_formatted_s

```
 alias_method :to_default_s, :to_s if instance_methods(false).include?(:to_s)
 alias_method :to_s, :to_formatted_s

```
(https://github.com/rails/rails/blob/v6.1.0/activesupport/lib/active_support/core_ext/date_time/conversions.rb#L42C1-L44C1)
That alias no longer exists in v7.1.5.1:
https://github.com/rails/rails/blob/v7.1.5.1/activesupport/lib/active_support/core_ext/date_time/conversions.rb

This PR merely changes the call to` to_s(:db)` in attribute_methods to use the non-deprecated `to_fs`.