### PR TITLE
Fix: Ensure symbolized keys for search arguments

### DIFF
--- a/lib/active_remote/search.rb
+++ b/lib/active_remote/search.rb
@@ -117,6 +117,11 @@ module ActiveRemote
       # Validates the given args to ensure they are compatible
       # Search args must be a hash or respond to to_hash
       #
+      # Returns a new hash with all keys (including nested) converted to symbols.
+      # This ensures consistent key access throughout the codebase, regardless of
+      # whether the input is a plain Hash, HashWithIndifferentAccess, or
+      # ActionController::Parameters.
+      #
       def validate_search_args!(args)
         unless args.is_a?(Hash)
           if args.respond_to?(:to_hash)
@@ -126,7 +131,9 @@ module ActiveRemote
           end
         end
 
-        args
+        # Convert all keys to symbols recursively to ensure consistent access
+        # with symbol keys throughout the codebase (e.g., args[:options][:pagination])
+        args.deep_symbolize_keys
       end
     end
 

--- a/spec/lib/active_remote/search_spec.rb
+++ b/spec/lib/active_remote/search_spec.rb
@@ -111,4 +111,114 @@ RSpec.describe ActiveRemote::Search do
       expect(subject.attributes).to eq attributes
     end
   end
+
+  describe ".validate_search_args!" do
+    context "when args is a hash with string keys" do
+      let(:args) { {"user_guid" => "123", "options" => {"pagination" => {"page" => 1}}} }
+
+      it "converts all keys to symbols" do
+        result = Tag.validate_search_args!(args)
+        expect(result).to eq({user_guid: "123", options: {pagination: {page: 1}}})
+      end
+
+      it "allows symbol key access on nested hashes" do
+        result = Tag.validate_search_args!(args)
+        expect(result[:options][:pagination][:page]).to eq(1)
+      end
+    end
+
+    context "when args is a hash with symbol keys" do
+      let(:args) { {user_guid: "123", options: {pagination: {page: 1}}} }
+
+      it "returns the hash with symbol keys unchanged" do
+        result = Tag.validate_search_args!(args)
+        expect(result).to eq({user_guid: "123", options: {pagination: {page: 1}}})
+      end
+    end
+
+    context "when args is a hash with mixed keys" do
+      let(:args) { {"user_guid" => "123", options: {pagination: {"page" => 1}}} }
+
+      it "converts all keys to symbols at all levels" do
+        result = Tag.validate_search_args!(args)
+        expect(result).to eq({user_guid: "123", options: {pagination: {page: 1}}})
+      end
+
+      it "allows consistent symbol key access" do
+        result = Tag.validate_search_args!(args)
+        expect(result[:user_guid]).to eq("123")
+        expect(result[:options][:pagination][:page]).to eq(1)
+      end
+    end
+
+    context "when args is a HashWithIndifferentAccess" do
+      let(:args) { HashWithIndifferentAccess.new("user_guid" => "123", "options" => {"pagination" => {"page" => 1}}) }
+
+      it "converts to a hash with symbol keys" do
+        result = Tag.validate_search_args!(args)
+        expect(result).to eq({user_guid: "123", options: {pagination: {page: 1}}})
+      end
+
+      it "allows symbol key access on all levels" do
+        result = Tag.validate_search_args!(args)
+        expect(result[:options][:pagination][:page]).to eq(1)
+      end
+    end
+
+    context "when args responds to to_hash" do
+      let(:object_with_to_hash) do
+        obj = double("params")
+        allow(obj).to receive(:to_hash).and_return({"user_guid" => "123", "options" => {"page" => 1}})
+        obj
+      end
+
+      it "calls to_hash and converts keys to symbols" do
+        result = Tag.validate_search_args!(object_with_to_hash)
+        expect(result).to eq({user_guid: "123", options: {page: 1}})
+      end
+    end
+
+    context "when args does not respond to to_hash and is not a hash" do
+      let(:invalid_args) { "invalid" }
+
+      it "raises an error" do
+        expect { Tag.validate_search_args!(invalid_args) }.to raise_error(RuntimeError, /Invalid parameter/)
+      end
+    end
+
+    context "when simulating ActionController::Parameters behavior" do
+      # Simulates: params.permit(:user_guid).merge(options: {...}).to_hash
+      let(:params_like_hash) do
+        obj = double("ActionController::Parameters")
+        # to_hash returns plain Hash with string keys (converts symbol keys to strings)
+        allow(obj).to receive(:to_hash).and_return({
+          "user_guid" => "123",
+          "options" => {
+            "pagination" => {
+              "page" => 1,
+              "per_page" => 10
+            }
+          }
+        })
+        obj
+      end
+
+      it "converts all string keys to symbols for consistent access" do
+        result = Tag.validate_search_args!(params_like_hash)
+        expect(result[:user_guid]).to eq("123")
+        expect(result[:options][:pagination][:page]).to eq(1)
+        expect(result[:options][:pagination][:per_page]).to eq(10)
+      end
+    end
+
+    context "when args contains arrays with hashes" do
+      let(:args) { {"filters" => [{"field" => "status", "value" => "active"}]} }
+
+      it "converts keys in nested array hashes to symbols" do
+        result = Tag.validate_search_args!(args)
+        expect(result).to eq({filters: [{field: "status", value: "active"}]})
+        expect(result[:filters].first[:field]).to eq("status")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Problem

When using `ActionController::Parameters` with merged options, calling `.to_hash` in `validate_search_args!`
converts all keys (including symbol keys) to strings, breaking symbol-based lookups in `active_remote-pagination`

```ruby
    search(attributes.merge(  # attributes is ActionController::Parameters
      :options => {
        :pagination => {
          :sort_column => :created_at,
          :sort_direction => ::Atlas::DBDirection::DESC,
          :page => 1,
          :per_page => 1,
        },
      },
    )).first
```

 ### Actual flow:
```ruby
  attributes = params.permit(:user_guid)
  # => ActionController::Parameters

  merged = attributes.merge(:options => {...})
  # => ActionController::Parameters (merge returns same type)

  # Inside validate_search_args!:
  args.to_hash
  # => {"user_guid" => "123", "options" => {"pagination" => {...}}}
  # All keys converted to STRINGS!

  # In active_remote-pagination:
  args[:options]  # => nil ✗ (key is actually "options" string)
```

### Key insight: 

ActionController::Parameters#merge returns another ActionController::Parameters, and calling .to_hash on it converts all keys to strings, even if they were originally symbols.

### Solution

  Modified validate_search_args! to normalize all keys to symbols using deep_symbolize_keys:


###  Result

```ruby
  attributes = params.permit(:user_guid)
  merged = attributes.merge(:options => {:pagination => {:page => 1}})

  # Inside validate_search_args!:
  args = merged.to_hash  # => {"user_guid" => "123", "options" => {...}}
  args = args.deep_symbolize_keys  # => {:user_guid => "123", :options => {...}}

  args[:options][:pagination]  # => {:page => 1} ✓
```